### PR TITLE
Use curl instead of wget

### DIFF
--- a/install-wasi-sdk.sh
+++ b/install-wasi-sdk.sh
@@ -25,9 +25,9 @@ if [[ ! -d $PATH_TO_SDK ]]; then
     VERSION_MAJOR="12"
     VERSION_MINOR="0"
     if [[ "$(uname -s)" == "Darwin" ]]; then
-        wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${VERSION_MAJOR}/wasi-sdk-${VERSION_MAJOR}.${VERSION_MINOR}-macos.tar.gz -O $TMPGZ
+        curl --fail --location --silent https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${VERSION_MAJOR}/wasi-sdk-${VERSION_MAJOR}.${VERSION_MINOR}-macos.tar.gz --output $TMPGZ
     else
-        wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${VERSION_MAJOR}/wasi-sdk-${VERSION_MAJOR}.${VERSION_MINOR}-linux.tar.gz -O $TMPGZ
+        curl --fail --location --silent https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${VERSION_MAJOR}/wasi-sdk-${VERSION_MAJOR}.${VERSION_MINOR}-linux.tar.gz --output $TMPGZ
     fi
     mkdir $PATH_TO_SDK
     tar xf $TMPGZ -C $PATH_TO_SDK --strip-components=1


### PR DESCRIPTION
MacOS doesn't have `wget` installed out-of-the-box so use `curl` instead.