### PR TITLE
Add target for opening docs for local crates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ core:
 				&& cargo build --release --target=wasm32-wasi \
 				&& cd -
 
+docs:
+		cd crates/core \
+				&& cargo doc --open --target=wasm32-wasi \
+				&& cd -
+
 test-core:
 		cd crates/core \
 				&& cargo wasi test --features json-io -- --nocapture \


### PR DESCRIPTION
This makes it easier to fetch documentation for crates being used in the project and the project's docs.