### PR TITLE
Add installing wask-sdk to publish.yml step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,9 @@ jobs:
           toolchain: 1.53.0
           target: wasm32-wasi
           default: true
+      
+      - name: Install wasi-sdk
+        run: make download-wasi-sdk
 
       - name: Make core
         run: make core


### PR DESCRIPTION
publish action was failing because the environment needs to do install wasi-sdk first. 

https://github.com/Shopify/javy/actions/runs/1893609362