### PR TITLE
Add version to dependency

### DIFF
--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["api-bindings"]
 
 [dependencies]
 anyhow = "1.0"
-quickjs-wasm-sys = { path = "../quickjs-wasm-sys" }
+quickjs-wasm-sys = { version = "0.1.0", path = "../quickjs-wasm-sys" }
 rmp-serde = { version = "^0.15", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde-transcode = { version = "1.1", optional = true }


### PR DESCRIPTION
Crates.io requires all dependencies include version numbers. Confirmed
that using a version number that doesn't correspond with adjacent crate
causes a build failure.