### PR TITLE
Add JSON support to quickjs-wasm-rs and CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,8 +822,8 @@ dependencies = [
  "anyhow",
  "binaryen",
  "lazy_static",
- "rmp-serde",
  "serde",
+ "serde_json",
  "structopt",
  "tempfile",
  "uuid",
@@ -841,9 +841,6 @@ dependencies = [
  "anyhow",
  "once_cell",
  "quickjs-wasm-rs",
- "rmp-serde",
- "serde-transcode",
- "serde_json",
  "wee_alloc",
 ]
 
@@ -1101,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -1110,6 +1107,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde-transcode",
+ "serde_json",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,12 @@ docs:
 
 test-quickjs-wasm-rs:
 		cd crates/quickjs-wasm-rs \
-				&& cargo wasi test --features messagepack \
+				&& cargo wasi test --features json \
 				&& cd -
 
 test-core:
 		cd crates/core \
-				&& cargo wasi test --features json-io -- --nocapture \
+				&& cargo wasi test -- --nocapture \
 				&& cd -
 
 # Test in release mode to skip some debug assertions

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,7 +20,7 @@ binaryen = "0.12.0"
 wasmtime = "0.34.1"
 wasmtime-wasi = "0.34.1"
 wasi-common = "0.34.1"
-rmp-serde = "0.15"
+serde_json = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
 lazy_static = "1.4"
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -87,9 +87,9 @@ where
     I: Serialize,
     O: DeserializeOwned,
 {
-    let input = rmp_serde::to_vec(i).unwrap();
+    let input = serde_json::to_vec(i).unwrap();
     let (output, logs) = r.exec(input).unwrap();
-    let output = rmp_serde::from_slice::<O>(&output).unwrap();
+    let output = serde_json::from_slice::<O>(&output).unwrap();
     let logs = String::from_utf8(logs).unwrap();
     (output, logs)
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -10,12 +10,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-quickjs-wasm-rs = { path = "../quickjs-wasm-rs", features = ["messagepack"] }
-serde-transcode = "1.1"
-rmp-serde = "^0.15"
+quickjs-wasm-rs = { path = "../quickjs-wasm-rs", features = ["json"] }
 wee_alloc = "0.4.5"
-serde_json = { version = "1", optional = true }
 once_cell = "1.4.0"
-
-[features]
-json-io = ["serde_json"]

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -5,31 +5,12 @@ pub fn load() -> Result<Vec<u8>> {
     let mut reader = stdin();
     let mut output: Vec<u8> = vec![];
 
-    #[cfg(not(feature = "json-io"))]
-    {
-        copy(&mut reader, &mut output)?;
-        Ok(output)
-    }
-    #[cfg(feature = "json-io")]
-    {
-        let mut input: Vec<u8> = vec![];
-        copy(&mut reader, &mut input)?;
-        let mut deserializer = serde_json::Deserializer::from_slice(&input);
-        let mut serializer = rmp_serde::Serializer::new(&mut output);
-        serde_transcode::transcode(&mut deserializer, &mut serializer)?;
-        Ok(output)
-    }
-}
-pub fn store(bytes: &[u8]) -> Result<()> {
-    #[cfg(feature = "json-io")]
-    let bytes = &{
-        let mut output = Vec::new();
-        let mut deserializer = rmp_serde::Deserializer::from_read_ref(bytes);
-        let mut serializer = serde_json::Serializer::new(&mut output);
-        serde_transcode::transcode(&mut deserializer, &mut serializer)?;
-        output
-    };
+    copy(&mut reader, &mut output)?;
 
+    Ok(output)
+}
+
+pub fn store(bytes: &[u8]) -> Result<()> {
     let mut handle = stdout();
     handle.write_all(bytes)?;
     handle.flush()?;

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -1,6 +1,6 @@
 mod engine;
 
-use quickjs_wasm_rs::{messagepack, Context, Value};
+use quickjs_wasm_rs::{json, Context, Value};
 
 use once_cell::sync::OnceCell;
 use std::io::{self, Read};
@@ -48,14 +48,14 @@ fn main() {
         let main = ENTRYPOINT.1.get().unwrap();
         let input_bytes = engine::load().expect("Couldn't load input");
 
-        let input_value = messagepack::transcode_input(context, &input_bytes).unwrap();
+        let input_value = json::transcode_input(context, &input_bytes).unwrap();
         let output_value = main.call(shopify, &[input_value]);
 
         if output_value.is_err() {
             panic!("{}", output_value.unwrap_err().to_string());
         }
 
-        let output = messagepack::transcode_output(output_value.unwrap()).unwrap();
+        let output = json::transcode_output(output_value.unwrap()).unwrap();
         engine::store(&output).expect("Couldn't store output");
     }
 }

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-rs"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Saúl Cabrera <saulecabrera@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -14,6 +14,7 @@ anyhow = "1.0"
 quickjs-wasm-sys = { version = "0.1.0", path = "../quickjs-wasm-sys" }
 rmp-serde = { version = "^0.15", optional = true }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", optional = true }
 serde-transcode = { version = "1.1", optional = true }
 convert_case = "0.4"
 
@@ -22,3 +23,4 @@ quickcheck = "1"
 
 [features]
 messagepack = ["rmp-serde", "serde-transcode"]
+json = ["serde_json", "serde-transcode"]

--- a/crates/quickjs-wasm-rs/README.md
+++ b/crates/quickjs-wasm-rs/README.md
@@ -16,7 +16,12 @@ will create a new context.
 
 ## Serializers
 
-Enabling the `messagepack` feature allows importing functions to serialize a messagepack byte array to a `Value` and deserialize from a `Value` to a messagepack byte array.
+This crate provides optional transcoding features for converting between
+serialization formats and `Value`:
+- `messagepack` provides `quickjs_wasm_rs::messagepack` for msgpack, using `rmp_serde`.
+- `json` provides `quickjs_wasm_rs::json` for JSON, using `serde_json`.
+
+msgpack example:
 
 ```rust
 use quickjs_wasm_rs::{messagepack, Context, Value};

--- a/crates/quickjs-wasm-rs/src/json.rs
+++ b/crates/quickjs-wasm-rs/src/json.rs
@@ -1,0 +1,19 @@
+use crate::serialize::de::Deserializer;
+use crate::serialize::ser::Serializer;
+use crate::{Context, Value};
+use anyhow::Result;
+
+pub fn transcode_input(context: &Context, bytes: &[u8]) -> Result<Value> {
+    let mut deserializer = serde_json::Deserializer::from_slice(bytes);
+    let mut serializer = Serializer::from_context(context)?;
+    serde_transcode::transcode(&mut deserializer, &mut serializer)?;
+    Ok(serializer.value)
+}
+
+pub fn transcode_output(val: Value) -> Result<Vec<u8>> {
+    let mut output = Vec::new();
+    let mut deserializer = Deserializer::from(val);
+    let mut serializer = serde_json::Serializer::new(&mut output);
+    serde_transcode::transcode(&mut deserializer, &mut serializer)?;
+    Ok(output)
+}

--- a/crates/quickjs-wasm-rs/src/lib.rs
+++ b/crates/quickjs-wasm-rs/src/lib.rs
@@ -6,3 +6,6 @@ pub use crate::js_binding::value::Value;
 
 #[cfg(feature = "messagepack")]
 pub mod messagepack;
+
+#[cfg(feature = "json")]
+pub mod json;


### PR DESCRIPTION
This PR introduces JSON as an additional optional format in the `quickjs-wasm-rs` crate, and swaps msgpack for JSON in the `core` and `cli` crates.

Once this merges, I'll cut a release (`0.3`) and coordinate the update to Shopify CLI.