### PR TITLE
add Context::execute_pending and Exception::from

### DIFF
--- a/crates/quickjs-wasm-rs/src/js_binding/context.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/context.rs
@@ -1,16 +1,18 @@
 use super::constants::{MAX_SAFE_INTEGER, MIN_SAFE_INTEGER};
+use super::exception::Exception;
 use super::value::Value;
 use anyhow::Result;
 use quickjs_wasm_sys::{
     ext_js_exception, ext_js_null, ext_js_undefined, size_t as JS_size_t, JSCFunctionData,
-    JSContext, JSValue, JS_Eval, JS_FreeCString, JS_GetGlobalObject, JS_NewArray, JS_NewBigInt64,
-    JS_NewBool_Ext, JS_NewCFunctionData, JS_NewContext, JS_NewFloat64_Ext, JS_NewInt32_Ext,
-    JS_NewInt64_Ext, JS_NewObject, JS_NewRuntime, JS_NewStringLen, JS_NewUint32_Ext,
-    JS_ToCStringLen2, JS_EVAL_TYPE_GLOBAL,
+    JSContext, JSValue, JS_Eval, JS_ExecutePendingJob, JS_FreeCString, JS_GetGlobalObject,
+    JS_GetRuntime, JS_NewArray, JS_NewBigInt64, JS_NewBool_Ext, JS_NewCFunctionData, JS_NewContext,
+    JS_NewFloat64_Ext, JS_NewInt32_Ext, JS_NewInt64_Ext, JS_NewObject, JS_NewRuntime,
+    JS_NewStringLen, JS_NewUint32_Ext, JS_ToCStringLen2, JS_EVAL_TYPE_GLOBAL,
 };
 use std::ffi::CString;
 use std::io::Write;
 use std::os::raw::{c_char, c_int, c_void};
+use std::ptr;
 
 #[derive(Debug)]
 pub struct Context {
@@ -49,6 +51,19 @@ impl Context {
         };
 
         Value::new(self.inner, raw)
+    }
+
+    pub fn execute_pending(&self) -> Result<()> {
+        let runtime = unsafe { JS_GetRuntime(self.inner) };
+
+        loop {
+            let mut ctx = ptr::null_mut();
+            match unsafe { JS_ExecutePendingJob(runtime, &mut ctx) } {
+                0 => break Ok(()),
+                1 => (),
+                _ => break Err(Exception::new(self.inner)?.into_error()),
+            }
+        }
     }
 
     pub fn global_object(&self) -> Result<Value> {

--- a/crates/quickjs-wasm-rs/src/js_binding/exception.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/exception.rs
@@ -22,12 +22,14 @@ impl fmt::Display for Exception {
 impl Exception {
     pub(super) fn new(context: *mut JSContext) -> Result<Self> {
         let exception_value = unsafe { JS_GetException(context) };
-        let exception_obj = Value::new_unchecked(context, exception_value);
+        Self::from(Value::new_unchecked(context, exception_value))
+    }
 
+    pub fn from(exception_obj: Value) -> Result<Self> {
         let msg = exception_obj.as_str().map(ToString::to_string)?;
         let mut stack = None;
 
-        let is_error = unsafe { JS_IsError(context, exception_value) } != 0;
+        let is_error = unsafe { JS_IsError(exception_obj.context, exception_obj.value) } != 0;
         if is_error {
             let stack_value = exception_obj.get_property("stack")?;
             if !stack_value.is_undefined() {

--- a/crates/quickjs-wasm-rs/src/js_binding/value.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/value.rs
@@ -18,8 +18,8 @@ pub enum BigInt {
 
 #[derive(Debug, Clone)]
 pub struct Value {
-    context: *mut JSContext,
-    value: JSValue,
+    pub(super) context: *mut JSContext,
+    pub(super) value: JSValue,
 }
 
 impl Value {

--- a/crates/quickjs-wasm-rs/src/lib.rs
+++ b/crates/quickjs-wasm-rs/src/lib.rs
@@ -2,6 +2,7 @@ mod js_binding;
 mod serialize;
 
 pub use crate::js_binding::context::Context;
+pub use crate::js_binding::exception::Exception;
 pub use crate::js_binding::value::Value;
 
 #[cfg(feature = "messagepack")]


### PR DESCRIPTION
This also makes `Exception` public.  These changes are useful for working with promises, e.g. when exceptions may be raised and values resolved asynchronously.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>