### PR TITLE
make `Serializer` and `Deserializer` public

### DIFF
--- a/crates/quickjs-wasm-rs/src/lib.rs
+++ b/crates/quickjs-wasm-rs/src/lib.rs
@@ -3,6 +3,8 @@ mod serialize;
 
 pub use crate::js_binding::context::Context;
 pub use crate::js_binding::value::Value;
+pub use crate::serialize::de::Deserializer;
+pub use crate::serialize::ser::Serializer;
 
 #[cfg(feature = "messagepack")]
 pub mod messagepack;


### PR DESCRIPTION
This allows programmers to convert between Rust values and QuickJS values directly (i.e. without going through JSON or MessagePack as an intermediate step).

Signed-off-by: Joel Dice <joel.dice@fermyon.com>