### PR TITLE
Fix command for updating javy

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -1,7 +1,7 @@
 # Javy npm package
 
-This is the npm package for javy. The package contains a small Node script
-that downloads the appropriate javy binary on demand and invokes it with the
+This is the npm package for Javy. The package contains a small Node script
+that downloads the appropriate Javy binary on demand and invokes it with the
 parameters given. 
 
 ## Usage
@@ -16,25 +16,25 @@ $ npx javy
 
 ## Updating javy
 
-The npm package won't download javy again once its downloaded. If a new
+The npm package won't download Javy again once its downloaded. If a new
 version of the javy npm package has been published, you can use the following
 invocation to update to the latest release:
 
 ```
-UPDATE_JAVY=1 npx jaxy
+REFRESH_JAVY=1 npx javy
 ```
 
 ## Building from source
 
 If there are no binaries available for your platform or the available binaries
-don't work for you for some reason, the npm package can also build javy from 
+don't work for you for some reason, the npm package can also build Javy from 
 source.
 
 ```
 BUILD_JAVY=1 npx javy
 ```
 
-Please note that for this to work you must have all prerequisites of javy
+Please note that for this to work you must have all prerequisites of Javy
 (listed in the [README]) installed. (That is CMake, Rust, Rust for wasm32-wasi
 target, cargo wasi, wasmtime-cli and Rosetta on Mac M1).
 


### PR DESCRIPTION
The update command had two errors:
1. The command name was misspelled as `jaxy` instead of `javy`
2. The env variable that's respected seems to be `REFRESH_JAVY` and not `UPDATE_JAVY`.