### PR TITLE
Fix rerun condition

### DIFF
--- a/crates/quickjs-wasm-sys/build.rs
+++ b/crates/quickjs-wasm-sys/build.rs
@@ -56,7 +56,7 @@ fn main() {
         .generate()
         .unwrap();
 
-    println!("cargo:rerun-if-changed=src/extensions/value.c");
+    println!("cargo:rerun-if-changed=extensions/value.c");
     println!("cargo:rerun-if-changed=wrapper.h");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());

--- a/crates/quickjs-wasm-sys/build.rs
+++ b/crates/quickjs-wasm-sys/build.rs
@@ -58,6 +58,7 @@ fn main() {
 
     println!("cargo:rerun-if-changed=extensions/value.c");
     println!("cargo:rerun-if-changed=wrapper.h");
+    println!("cargo:rerun-if-changed=quickjs");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings.write_to_file(out_dir.join("bindings.rs")).unwrap();


### PR DESCRIPTION
the current rerun conditions for quickjs-wasm-sys builds include a non-existing path

Cargo's behavior is to rebuild every time if any of the files is missing, so that was the current behavior

I fixed the wrong rerun-if-changed condition and added another one to make sure the crate gets rebuilt any time the C code was changed