### PR TITLE
handle arbitrary-sized closures correctly in `new_callback`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opaque-debug"
@@ -1024,6 +1024,7 @@ version = "0.1.2"
 dependencies = [
  "anyhow",
  "convert_case",
+ "once_cell",
  "quickcheck",
  "quickjs-wasm-sys",
  "rmp-serde",

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 serde-transcode = { version = "1.1", optional = true }
 convert_case = "0.4"
+once_cell = "1.16"
 
 [dev-dependencies]
 quickcheck = "1"

--- a/crates/quickjs-wasm-rs/src/js_binding/value.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/value.rs
@@ -1,13 +1,17 @@
+use super::context;
 use super::exception::Exception;
 use super::properties::Properties;
 use anyhow::{anyhow, Result};
 use quickjs_wasm_sys::{
     size_t as JS_size_t, JSContext, JSValue, JS_BigIntSigned, JS_BigIntToInt64, JS_BigIntToUint64,
     JS_Call, JS_DefinePropertyValueStr, JS_DefinePropertyValueUint32, JS_GetArrayBuffer,
-    JS_GetPropertyStr, JS_GetPropertyUint32, JS_IsArray, JS_IsArrayBuffer_Ext, JS_IsFloat64_Ext,
-    JS_IsFunction, JS_ToCStringLen2, JS_ToFloat64, JS_PROP_C_W_E, JS_TAG_BIG_INT, JS_TAG_BOOL,
-    JS_TAG_EXCEPTION, JS_TAG_INT, JS_TAG_NULL, JS_TAG_OBJECT, JS_TAG_STRING, JS_TAG_UNDEFINED,
+    JS_GetOpaque, JS_GetPropertyStr, JS_GetPropertyUint32, JS_IsArray, JS_IsArrayBuffer_Ext,
+    JS_IsFloat64_Ext, JS_IsFunction, JS_ToCStringLen2, JS_ToFloat64, JS_PROP_C_W_E, JS_TAG_BIG_INT,
+    JS_TAG_BOOL, JS_TAG_EXCEPTION, JS_TAG_INT, JS_TAG_NULL, JS_TAG_OBJECT, JS_TAG_STRING,
+    JS_TAG_UNDEFINED,
 };
+use std::any::TypeId;
+use std::cell::RefCell;
 use std::ffi::CString;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -241,6 +245,26 @@ impl Value {
 
     pub fn is_exception(&self) -> bool {
         self.get_tag() == JS_TAG_EXCEPTION
+    }
+
+    /// Get a pointer to the `RefCell` holding a value wrapped using [Context::wrap_rust_value].
+    pub fn get_rust_value<T: 'static>(&self) -> Result<&RefCell<T>> {
+        unsafe {
+            let pointer = JS_GetOpaque(
+                self.value,
+                *context::CLASSES
+                    .lock()
+                    .unwrap()
+                    .get(&TypeId::of::<T>())
+                    .unwrap(),
+            ) as *const RefCell<T>;
+
+            if pointer.is_null() {
+                Err(anyhow!("type mismatch"))
+            } else {
+                Ok(&*pointer)
+            }
+        }
     }
 
     fn get_tag(&self) -> i32 {

--- a/crates/quickjs-wasm-rs/src/js_binding/value.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/value.rs
@@ -592,7 +592,8 @@ mod tests {
     fn test_is_function() {
         let ctx = Context::default();
 
-        ctx.eval_global("main", "var x = 42; function foo() {}");
+        ctx.eval_global("main", "var x = 42; function foo() {}")
+            .unwrap();
 
         assert!(!ctx
             .global_object()


### PR DESCRIPTION
Previously, `Context::new_callback` would not work reliably for closures larger than 4 bytes in size.  This fixes that by moving the closure into a `Box` and passing the pointer to QuickJS instead of the closure itself.

Note that the boxed closure is leaked, which seems unavoidable given that QuickJS provides no way to specify custom finalizers for `JSValue`s.  However, `quickjs-wasm-rs` already leaks memory in various ways, which we consider acceptable since it is intended for short-lived programs.

This also adds a `'static` bound to the closure type, ensuring that non-`static` borrows are rejected at compile time, which makes `new_callback` safe to use without an `unsafe` block (although `unsafe` will generally be needed in the _body_ of the closure -- use `wrap_callback` to avoid that).

Signed-off-by: Joel Dice <joel.dice@fermyon.com>