### PR TITLE
Modifying the sanitization of json keys to use camel instead of snake casing

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
         ),
     )?;
 
-    memory.write(&mut store, contents_ptr.try_into()?, &mut buffer)?;
+    memory.write(&mut store, contents_ptr.try_into()?, &buffer)?;
     let bytecode_ptr = instance
         .get_typed_func::<(u32, u32, u32), u32, _>(&mut store, "compile-bytecode")?
         .call(

--- a/crates/cli/tests/runner/mod.rs
+++ b/crates/cli/tests/runner/mod.rs
@@ -65,10 +65,13 @@ impl Runner {
         let root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
         let wasm_file = std::env::temp_dir().join(wasm_file_name);
         let js_file = root.join("tests").join("sample-scripts").join(js_file);
+        let javy_core = root.join("../../target/wasm32-wasi/release/javy_core.wasm");
 
         let output = Command::new(env!("CARGO_BIN_EXE_javy"))
             .current_dir(root)
             .arg(&js_file)
+            .arg("-j")
+            .arg(javy_core)
             .arg("-o")
             .arg(&wasm_file)
             .output()

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -36,6 +36,12 @@ pub unsafe extern "C" fn init_engine() {
     JS_CONTEXT.set(context).unwrap();
 }
 
+/// Compiles the bytecode for the JS engine to run
+///
+/// # Safety
+///
+/// See safety for https://doc.rust-lang.org/nightly/std/slice/fn.from_raw_parts_mut.html
+/// See safety for https://doc.rust-lang.org/nightly/std/str/fn.from_utf8_unchecked.html
 #[export_name = "compile-bytecode"]
 pub unsafe extern "C" fn compile_bytecode(
     contents_ptr: *mut u8,

--- a/crates/quickjs-wasm-rs/src/serialize/de.rs
+++ b/crates/quickjs-wasm-rs/src/serialize/de.rs
@@ -87,7 +87,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer {
         if self.value.is_str() {
             if self.map_key {
                 self.map_key = false;
-                let key = sanitize_key(&self.value, convert_case::Case::Snake)?;
+                let key = sanitize_key(&self.value, convert_case::Case::Camel)?;
                 return visitor.visit_str(key.as_str());
             } else {
                 let val = self.value.as_str()?;
@@ -307,10 +307,10 @@ mod tests {
     }
 
     #[test]
-    fn test_map_keys_are_converted_to_snake_case() {
+    fn test_map_keys_are_converted_to_camel_case() {
         let context = Context::default();
         let val = context.object_value().unwrap();
-        val.set_property("hello_wold", context.value_from_i32(1).unwrap())
+        val.set_property("hello_world", context.value_from_i32(1).unwrap())
             .unwrap();
         val.set_property("toto", context.value_from_i32(2).unwrap())
             .unwrap();
@@ -323,11 +323,15 @@ mod tests {
 
         let actual = deserialize_value::<BTreeMap<String, i32>>(val);
 
-        assert_eq!(1, *actual.get("hello_wold").unwrap());
+        for key in actual.keys() {
+            println!("{}", key);
+        }
+
+        assert_eq!(1, *actual.get("helloWorld").unwrap());
         assert_eq!(2, *actual.get("toto").unwrap());
-        assert_eq!(3, *actual.get("foo_bar").unwrap());
-        assert_eq!(4, *actual.get("joyeux_noël").unwrap());
-        assert_eq!(5, *actual.get("kebab_case").unwrap());
+        assert_eq!(3, *actual.get("fooBar").unwrap());
+        assert_eq!(4, *actual.get("joyeuxNoël").unwrap());
+        assert_eq!(5, *actual.get("kebabCase").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
#gsd:31055

Modifying the sanitization of json keys to use came instead of snake casing