### PR TITLE
Inherit stderr when running benchmarks

### DIFF
--- a/crates/cli/benches/benchmark.rs
+++ b/crates/cli/benches/benchmark.rs
@@ -88,11 +88,10 @@ impl Function {
 
     pub fn setup(&self) -> Result<(Linker<WasiCtx>, Store<WasiCtx>), Box<dyn Error>> {
         let mut linker = Linker::new(&self.engine);
-        let stdout = WritePipe::new_in_memory();
         let wasi = WasiCtxBuilder::new()
             .stdin(Box::new(ReadPipe::from(&self.payload[..])))
-            .stdout(Box::new(stdout.clone()))
-            .stderr(Box::new(stdout))
+            .stdout(Box::new(WritePipe::new_in_memory()))
+            .inherit_stderr()
             .build();
         wasmtime_wasi::add_to_linker(&mut linker, |s| s).unwrap();
         let store = Store::new(&self.engine, wasi);


### PR DESCRIPTION
This makes it a lot easier to debug when a trap is triggered in a benchmark