### PR TITLE
Add TextEncoder and TextDecoder APIs

### DIFF
--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -49,6 +49,18 @@ fn test_str() {
 }
 
 #[test]
+fn test_encoding() {
+    let _guard = EXCLUSIVE_TEST.lock();
+    let mut runner = Runner::new("text-encoding.js");
+
+    let (output, _) = run::<_, String>(&mut runner, &"hello");
+    assert_eq!("el", output.as_str());
+
+    let (output, _) = run::<_, String>(&mut runner, &"test");
+    assert_eq!("test2", output.as_str());
+}
+
+#[test]
 fn test_big_ints() {
     let _guard = EXCLUSIVE_TEST.lock();
     let mut runner = Runner::new("big-ints.js");

--- a/crates/cli/tests/sample-scripts/text-encoding.js
+++ b/crates/cli/tests/sample-scripts/text-encoding.js
@@ -1,0 +1,13 @@
+var Shopify = {
+    main: (i) => {
+        const decoder = new TextDecoder();
+        const encoder = new TextEncoder();
+        if (i === "hello") {
+            const offset = 1;
+            const length = 2;
+            return decoder.decode(new Uint8Array(encoder.encode(i).buffer, offset, length));
+        } else {
+            return decoder.decode(new Uint8Array(Array.from(encoder.encode(i)).concat("2".charCodeAt(0))));
+        }
+    }
+}

--- a/crates/core/prelude_scripts/prelude.js
+++ b/crates/core/prelude_scripts/prelude.js
@@ -1,0 +1,54 @@
+class TextDecoder {
+    constructor(label = "utf-8", options = {}) {
+        if (label !== "utf-8") {
+            // Not spec-compliant behaviour
+            throw new RangeError("The encoding label provided must be utf-8");
+        }
+        Object.defineProperties(this, {
+            encoding: { value: "utf-8", enumerable: true, writable: false },
+            fatal: { value: !!options.fatal, enumerable: true, writable: false },
+            ignoreBOM: { value: !!options.ignoreBOM, enumerable: true, writable: false },
+        })
+    }
+
+    decode(input, options = {}) {
+        if (input === undefined) {
+            return "";
+        }
+
+        if (options.stream) {
+            throw new Error("Streaming decode is not supported");
+        }
+
+        // backing buffer would not have byteOffset and may have different byteLength
+        let byteOffset = input.byteOffset || 0;
+        let byteLength = input.byteLength;
+        if (ArrayBuffer.isView(input)) {
+            input = input.buffer;
+        }
+
+        if (!(input instanceof ArrayBuffer)) {
+            throw new TypeError("The provided value is not of type '(ArrayBuffer or ArrayBufferView)'");
+        }
+
+        // ignoreBOM does not appear to change behaviour for UTF-8
+        return Javy.decodeUtf8BufferToString(input, byteOffset, byteLength, this.fatal);
+    }
+}
+
+class TextEncoder {
+    constructor() {
+        Object.defineProperties(this, {
+            encoding: { value: "utf-8", enumerable: true, writable: false },
+        });
+    }
+
+    encode(input) {
+        input = input.toString(); // non-string inputs are converted to strings
+        return new Uint8Array(Javy.encodeStringToUtf8(input));
+    }
+
+    encodeInto(source, destination) {
+        throw new Error("encodeInto is not supported");
+    }
+}

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -26,6 +26,9 @@ pub extern "C" fn init() {
         context
             .register_globals(io::stderr(), io::stderr())
             .unwrap();
+        context
+            .eval_global("prelude.js", include_str!("../prelude_scripts/prelude.js"))
+            .unwrap();
 
         let mut contents = String::new();
         io::stdin().read_to_string(&mut contents).unwrap();

--- a/crates/quickjs-wasm-rs/src/js_binding/context.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/context.rs
@@ -1,7 +1,7 @@
 use super::constants::{MAX_SAFE_INTEGER, MIN_SAFE_INTEGER};
 use super::exception::Exception;
 use super::value::Value;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use once_cell::sync::Lazy;
 use quickjs_wasm_sys::{
     ext_js_exception, ext_js_null, ext_js_undefined, size_t as JS_size_t, JSCFunctionData,
@@ -13,6 +13,7 @@ use quickjs_wasm_sys::{
     JS_ToCStringLen2, JS_EVAL_TYPE_GLOBAL,
 };
 use std::any::TypeId;
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -20,6 +21,7 @@ use std::ffi::CString;
 use std::io::Write;
 use std::os::raw::{c_char, c_int, c_void};
 use std::ptr;
+use std::str;
 use std::sync::Mutex;
 
 pub(super) static CLASSES: Lazy<Mutex<HashMap<TypeId, JSClassID>>> =
@@ -275,6 +277,18 @@ impl Context {
         console_object.set_property("log", console_log_callback)?;
         console_object.set_property("error", console_error_callback)?;
         global_object.set_property("console", console_object)?;
+
+        let javy_object = self.object_value()?;
+        javy_object.set_property(
+            "decodeUtf8BufferToString",
+            self.wrap_callback(decode_utf8_buffer_to_js_string())?,
+        )?;
+        javy_object.set_property(
+            "encodeStringToUtf8",
+            self.wrap_callback(encode_js_string_to_utf8_buffer())?,
+        )?;
+        global_object.set_property("Javy", javy_object)?;
+
         Ok(())
     }
 }
@@ -307,6 +321,56 @@ where
 
         writeln!(stream,).unwrap();
         unsafe { ext_js_undefined }
+    }
+}
+
+fn decode_utf8_buffer_to_js_string() -> impl FnMut(&Context, &Value, &[Value]) -> Result<Value> {
+    move |ctx: &Context, _this: &Value, args: &[Value]| {
+        if args.len() != 4 {
+            return Err(anyhow!("Expecting 4 arguments, received {}", args.len()));
+        }
+
+        let buffer = args[0].as_bytes()?;
+        let byte_offset = {
+            let byte_offset_val = &args[1];
+            if !byte_offset_val.is_repr_as_i32() {
+                return Err(anyhow!("byte_offset must be an u32"));
+            }
+            byte_offset_val.as_u32_unchecked()
+        }
+        .try_into()?;
+        let byte_length: usize = {
+            let byte_length_val = &args[2];
+            if !byte_length_val.is_repr_as_i32() {
+                return Err(anyhow!("byte_length must be an u32"));
+            }
+            byte_length_val.as_u32_unchecked()
+        }
+        .try_into()?;
+        let fatal = args[3].as_bool()?;
+
+        let view = buffer
+            .get(byte_offset..(byte_offset + byte_length))
+            .ok_or(anyhow!(
+                "Provided offset and length is not valid for provided buffer"
+            ))?;
+        let str = if fatal {
+            Cow::from(str::from_utf8(view).map_err(|_| anyhow!("The encoded data was not valid"))?)
+        } else {
+            String::from_utf8_lossy(view)
+        };
+        ctx.value_from_str(&str)
+    }
+}
+
+fn encode_js_string_to_utf8_buffer() -> impl FnMut(&Context, &Value, &[Value]) -> Result<Value> {
+    move |ctx: &Context, _this: &Value, args: &[Value]| {
+        if args.len() != 1 {
+            return Err(anyhow!("Expecting 1 argument, got {}", args.len()));
+        }
+
+        let js_string = args[0].as_str()?;
+        ctx.array_buffer_value(js_string.as_bytes())
     }
 }
 


### PR DESCRIPTION
First part of a set of changes to alter how JS code is executed inside Javy. Also adds a JS script that is evaluated before the users' JS to have an easier time adding new JS APIs that would be more difficult to define in Rust.