### PR TITLE
Use Cargo inheritance and cleanup Cargo.tomls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,19 @@ members = [
   "crates/cli",
 ]
 
+[workspace.package]
+version = "0.3.0"
+authors = ["The Javy Project Developers"]
+edition = "2021"
+license = "MIT"
+
+[workspace.dependencies]
+wasmtime = "0.34.1"
+wasmtime-wasi = "0.34.1"
+wasi-common = "0.34.1"
+anyhow = "1.0"
+once_cell = "1.16"
+
 [profile.release]
 lto = true
 opt-level = 3

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "javy"
-version = "0.1.0"
-authors = ["Saúl Cabrera <saulecabrera@gmail.com>"]
-edition = "2018"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 build = "build.rs"
 
 [[bin]]
@@ -12,14 +13,14 @@ name = "javy"
 wizer = { git = "https://github.com/bytecodealliance/wizer", branch = "main" }
 which = "4.2"
 structopt = "0.3"
-anyhow = "1.0"
+anyhow = { workspace = true }
 tempfile = "3.2.0"
 binaryen = "0.12.0"
 
 [dev-dependencies]
-wasmtime = "0.34.2"
-wasmtime-wasi = "0.34.2"
-wasi-common = "0.34.2"
+wasmtime = { workspace = true }
+wasmtime-wasi = { workspace = true }
+wasi-common = { workspace = true }
 serde_json = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
 lazy_static = "1.4"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "javy-core"
 version = "0.1.0"
-authors = ["Saúl Cabrera <saulecabrera@gmail.com>"]
-edition = "2018"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "javy_core"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 quickjs-wasm-rs = { path = "../quickjs-wasm-rs", features = ["json"] }
-once_cell = "1.4.0"
+once_cell = { workspace = true }

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "quickjs-wasm-rs"
 version = "0.1.2"
-authors = ["Saúl Cabrera <saulecabrera@gmail.com>"]
-edition = "2018"
-license = "MIT"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "High-level bindings and serializers for a Wasm build of QuickJS"
 homepage = "https://github.com/Shopify/javy/tree/main/crates/quickjs-wasm-rs"
 repository = "https://github.com/Shopify/javy/tree/main/crates/quickjs-wasm-rs"
 categories = ["api-bindings"]
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 quickjs-wasm-sys = { version = "0.1.0", path = "../quickjs-wasm-sys" }
 rmp-serde = { version = "^0.15", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/quickjs-wasm-sys/Cargo.toml
+++ b/crates/quickjs-wasm-sys/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "quickjs-wasm-sys"
 version = "0.1.0"
-authors = ["Saúl Cabrera <saulecabrera@gmail.com>"]
-edition = "2018"
-license = "MIT"
+authors.workspace = true
+edition.workspace = true 
+license.workspace = true
 description = "Rust bindings for Wasm build of QuickJS"
 homepage = "https://github.com/Shopify/javy/tree/main/crates/quickjs-wasm-sys"
 repository = "https://github.com/Shopify/javy/tree/main/crates/quickjs-wasm-sys"


### PR DESCRIPTION
This commit uses cargo inheritance to declare the common dependendencies in the root Cargo.toml and also cleans up the Cargo.toml definitions.