### PR TITLE
Forcing the wasm32-wasi target when building quickjs-sys

### DIFF
--- a/crates/quickjs-wasm-sys/build.rs
+++ b/crates/quickjs-wasm-sys/build.rs
@@ -45,6 +45,7 @@ fn main() {
         .flag_if_supported("-Wno-cast-function-type")
         .flag_if_supported("-Wno-implicit-fallthrough")
         .flag_if_supported("-Wno-enum-conversion")
+        .target("wasm32-wasi")
         .opt_level(2)
         .compile("quickjs");
 


### PR DESCRIPTION
I've been getting this error when running `rust-analyzer` in the `javy` repo:

```
[ERROR][2022-12-08 15:22:14] .../vim/lsp/rpc.lua:733	"rpc"	"rust-analyzer"	"stderr"	"[ERROR rust_analyzer::lsp_utils] failed to run build scripts\n\nThe following warnings were emitted during compilation:\n\n\nerror: failed to run custom build command for `quickjs-wasm-sys v0.1.0 (/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys)`\n\nCaused by:\n  process didn't exit successfully: `/Users/kevinrizzo/src/github.com/Shopify/javy/target/debug/build/quickjs-wasm-sys-28c5cce3d5bf3c9c/build-script-build` (exit status: 1)\n  --- stdout\n  TARGET = Some(\"aarch64-apple-darwin\")\n  HOST = Some(\"aarch64-apple-darwin\")\n  CC_aarch64-apple-darwin = None\n  CC_aarch64_apple_darwin = None\n  HOST_CC = None\n  CC = Some(\"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\")\n  CFLAGS_aarch64-apple-darwin = None\n  CFLAGS_aarch64_apple_darwin = None\n  HOST_CFLAGS = None\n  CFLAGS = Some(\"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\")\n  CRATE_CC_NO_DEFAULTS = None\n  DEBUG = Some(\"true\")\n  CC_aarch64-apple-darwin = None\n  CC_aarch64_apple_darwin = None\n  HOST_CC = None\n  CC = Some(\"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\")\n  CFLAGS_aarch64-apple-darwin = None\n  CFLAGS_aarch64_apple_darwin = None\n  HOST_CFLAGS = None\n  CFLAGS = Some(\"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\")\n  CRATE_CC_NO_DEFAULTS = None\n  CC_aarch64-apple-darwin = None\n  CC_aarch64_apple_darwin = None\n  HOST_CC = None\n  CC = Some(\"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\")\n  CFLAGS_aarch64-apple-darwin = None\n  CFLAGS_aarch64_apple_darwin = None\n  HOST_CFLAGS = None\n  CFLAGS = Some(\"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\")\n  CRATE_CC_NO_DEFAULTS = None\n  CC_aarch64-apple-darwin = None\n  CC_aarch64_apple_darwin = None\n  HOST_CC = None\n  CC = Some(\"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\")\n  CFLAGS_aarch64-apple-darwin = None\n  CFLAGS_aarch64_apple_darwin = None\n  HOST_CFLAGS = None\n  CFLAGS = Some(\"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\")\n  CRATE_CC_NO_DEFAULTS = None\n  CC_aarch64-apple-darwin = None\n  CC_aarch64_apple_darwin = None\n  HOST_CC = None\n  CC = Some(\"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\")\n  CFLAGS_aarch64-apple-darwin = None\n  CFLAGS_aarch64_apple_darwin = None\n  HOST_CFLAGS = None\n  CFLAGS = Some(\"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\")\n  CRATE_CC_NO_DEFAULTS = None\n  CC_aarch64-apple-darwin = None\n  CC_aarch64_apple_darwin = None\n  HOST_CC = None\n  CC = Some(\"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\")\n  CFLAGS_aarch64-apple-darwin = None\n  CFLAGS_aarch64_apple_darwin = None\n  HOST_CFLAGS = None\n  CFLAGS = Some(\"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\")\n  CRATE_CC_NO_DEFAULTS = None\n  CC_aarch64-apple-darwin = None\n  CC_aarch64_apple_darwin = None\n  HOST_CC = None\n  CC = Some(\"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\")\n  CFLAGS_aarch64-apple-darwin = None\n  CFLAGS_aarch64_apple_darwin = None\n  HOST_CFLAGS = None\n  CFLAGS = Some(\"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\")\n  CRATE_CC_NO_DEFAULTS = None\n  CC_aarch64-apple-darwin = None\n  CC_aarch64_apple_darwin = None\n  HOST_CC = None\n  CC = Some(\"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\")\n  CFLAGS_aarch64-apple-darwin = None\n  CFLAGS_aarch64_apple_darwin = None\n  HOST_CFLAGS = None\n  CFLAGS = Some(\"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\")\n  CRATE_CC_NO_DEFAULTS = None\n  CC_aarch64-apple-darwin = None\n  CC_aarch64_apple_darwin = None\n  HOST_CC = None\n  CC = Some(\"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\")\n  CFLAGS_aarch64-apple-darwin = None\n  CFLAGS_aarch64_apple_darwin = None\n  HOST_CFLAGS = None\n  CFLAGS = Some(\"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\")\n  CRATE_CC_NO_DEFAULTS = None\n  CC_aarch64-apple-darwin = None\n  CC_aarch64_apple_darwin = None\n  HOST_CC = None\n  CC = Some(\"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\")\n  CFLAGS_aarch64-apple-darwin = None\n  CFLAGS_aarch64_apple_darwin = None\n  HOST_CFLAGS = None\n  CFLAGS = Some(\"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\")\n  CRATE_CC_NO_DEFAULTS = None\n  CC_aarch64-apple-darwin = None\n  CC_aarch64_apple_darwin = None\n  HOST_CC = None\n  CC = Some(\"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\")\n  CFLAGS_aarch64-apple-darwin = None\n  CFLAGS_aarch64_apple_darwin = None\n  HOST_CFLAGS = None\n  CFLAGS = Some(\"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\")\n  CRATE_CC_NO_DEFAULTS = None\n  CC_aarch64-apple-darwin = None\n  CC_aarch64_apple_darwin = None\n  HOST_CC = None\n  CC = Some(\"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\")\n  CFLAGS_aarch64-apple-darwin = None\n  CFLAGS_aarch64_apple_darwin = None\n  HOST_CFLAGS = None\n  CFLAGS = Some(\"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\")\n  CRATE_CC_NO_DEFAULTS = None\n  CC_aarch64-apple-darwin = None\n  CC_aarch64_apple_darwin = None\n  HOST_CC = None\n  CC = Some(\"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\")\n  CFLAGS_aarch64-apple-darwin = None\n  CFLAGS_aarch64_apple_darwin = None\n  HOST_CFLAGS = None\n  CFLAGS = Some(\"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\")\n  CRATE_CC_NO_DEFAULTS = None\n  CC_aarch64-apple-darwin = None\n  CC_aarch64_apple_darwin = None\n  HOST_CC = None\n  CC = Some(\"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\")\n  CFLAGS_aarch64-apple-darwin = None\n  CFLAGS_aarch64_apple_darwin = None\n  HOST_CFLAGS = None\n  CFLAGS = Some(\"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\")\n  CRATE_CC_NO_DEFAULTS = None\n  CC_aarch64-apple-darwin = None\n  CC_aarch64_apple_darwin = None\n  HOST_CC = None\n  CC = Some(\"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\")\n  CFLAGS_aarch64-apple-darwin = None\n  CFLAGS_aarch64_apple_darwin = None\n  HOST_CFLAGS = None\n  CFLAGS = Some(\"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\")\n  CRATE_CC_NO_DEFAULTS = None\n  running: \"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\" \"-O2\" \"-ffunction-sections\" \"-fdata-sections\" \"-fPIC\" \"-g\" \"-fno-omit-frame-pointer\" \"--target=arm64-apple-darwin\" \"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\" \"-D_GNU_SOURCE\" \"-DCONFIG_VERSION=\\\"2021-03-27\\\"\" \"-DCONFIG_BIGNUM\" \"-o\" \"/Users/kevinrizzo/src/github.com/Shopify/javy/target/debug/build/quickjs-wasm-sys-747b0ccd15a56209/out/extensions/value.o\" \"-c\" \"extensions/value.c\"\n  running: \"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\" \"-O2\" \"-ffunction-sections\" \"-fdata-sections\" \"-fPIC\" \"-g\" \"-fno-omit-frame-pointer\" \"--target=arm64-apple-darwin\" \"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\" \"-D_GNU_SOURCE\" \"-DCONFIG_VERSION=\\\"2021-03-27\\\"\" \"-DCONFIG_BIGNUM\" \"-o\" \"/Users/kevinrizzo/src/github.com/Shopify/javy/target/debug/build/quickjs-wasm-sys-747b0ccd15a"
[ERROR][2022-12-08 15:22:14] .../vim/lsp/rpc.lua:733	"rpc"	"rust-analyzer"	"stderr"	"56209/out/quickjs/libregexp.o\" \"-c\" \"quickjs/libregexp.c\"\n  running: \"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\" \"-O2\" \"-ffunction-sections\" \"-fdata-sections\" \"-fPIC\" \"-g\" \"-fno-omit-frame-pointer\" \"--target=arm64-apple-darwin\" \"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\" \"-D_GNU_SOURCE\" \"-DCONFIG_VERSION=\\\"2021-03-27\\\"\" \"-DCONFIG_BIGNUM\" \"-o\" \"/Users/kevinrizzo/src/github.com/Shopify/javy/target/debug/build/quickjs-wasm-sys-747b0ccd15a56209/out/quickjs/libbf.o\" \"-c\" \"quickjs/libbf.c\"\n  running: \"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\" \"-O2\" \"-ffunction-sections\" \"-fdata-sections\" \"-fPIC\" \"-g\" \"-fno-omit-frame-pointer\" \"--target=arm64-apple-darwin\" \"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\" \"-D_GNU_SOURCE\" \"-DCONFIG_VERSION=\\\"2021-03-27\\\"\" \"-DCONFIG_BIGNUM\" \"-o\" \"/Users/kevinrizzo/src/github.com/Shopify/javy/target/debug/build/quickjs-wasm-sys-747b0ccd15a56209/out/quickjs/cutils.o\" \"-c\" \"quickjs/cutils.c\"\n  running: \"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\" \"-O2\" \"-ffunction-sections\" \"-fdata-sections\" \"-fPIC\" \"-g\" \"-fno-omit-frame-pointer\" \"--target=arm64-apple-darwin\" \"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\" \"-D_GNU_SOURCE\" \"-DCONFIG_VERSION=\\\"2021-03-27\\\"\" \"-DCONFIG_BIGNUM\" \"-o\" \"/Users/kevinrizzo/src/github.com/Shopify/javy/target/debug/build/quickjs-wasm-sys-747b0ccd15a56209/out/quickjs/libunicode.o\" \"-c\" \"quickjs/libunicode.c\"\n  running: \"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\" \"-O2\" \"-ffunction-sections\" \"-fdata-sections\" \"-fPIC\" \"-g\" \"-fno-omit-frame-pointer\" \"--target=arm64-apple-darwin\" \"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\" \"-D_GNU_SOURCE\" \"-DCONFIG_VERSION=\\\"2021-03-27\\\"\" \"-DCONFIG_BIGNUM\" \"-o\" \"/Users/kevinrizzo/src/github.com/Shopify/javy/target/debug/build/quickjs-wasm-sys-747b0ccd15a56209/out/quickjs/quickjs.o\" \"-c\" \"quickjs/quickjs.c\"\n  cargo:warning=quickjs/cutils.c:25:10: fatal error: 'stdlib.h' file not found\n  cargo:warning=quickjs/libunicode.c:24:10: fatal error: 'stdlib.h' file not found\n  cargo:warning=#include <stdlib.h>\n  cargo:warning=         ^~~~~~~~~~\n  cargo:warning=#include <stdlib.h>\n  cargo:warning=         ^~~~~~~~~~\n  cargo:warning=In file included from extensions/value.c:1:\n  cargo:warning=extensions/../quickjs/quickjs.h:28:10: fatal error: 'stdio.h' file not found\n  cargo:warning=#include <stdio.h>\n  cargo:warning=         ^~~~~~~~~\n  cargo:warning=quickjs/libregexp.c:24:10: fatal error: 'stdlib.h' file not found\n  cargo:warning=#include <stdlib.h>\n  cargo:warning=         ^~~~~~~~~~\n  cargo:warning=quickjs/libbf.c:24:10: fatal error: 'stdlib.h' file not found\n  cargo:warning=#include <stdlib.h>\n  cargo:warning=         ^~~~~~~~~~\n  cargo:warning=quickjs/quickjs.c:25:10: fatal error: 'stdlib.h' file not found\n  cargo:warning=#include <stdlib.h>\n  cargo:warning=         ^~~~~~~~~~\n  cargo:warning=1 error generated.\n  cargo:warning=1 error generated.\n  exit status: 1\n  exit status: 1\n  cargo:warning=1 error generated.\n  exit status: 1\n  cargo:warning=1 error generated.\n  exit status: 1\n  cargo:warning=1 error generated.\n  exit status: 1\n  cargo:warning=1 error generated.\n  exit status: 1\n\n  --- stderr\n\n\n  error occurred: Command \"/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/bin/clang\" \"-O2\" \"-ffunction-sections\" \"-fdata-sections\" \"-fPIC\" \"-g\" \"-fno-omit-frame-pointer\" \"--target=arm64-apple-darwin\" \"--sysroot=/Users/kevinrizzo/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot\" \"-D_GNU_SOURCE\" \"-DCONFIG_VERSION=\\\"2021-03-27\\\"\" \"-DCONFIG_BIGNUM\" \"-o\" \"/Users/kevinrizzo/src/github.com/Shopify/javy/target/debug/build/quickjs-wasm-sys-747b0ccd15a56209/out/quickjs/cutils.o\" \"-c\" \"quickjs/cutils.c\" with args \"clang\" did not execute successfully (status code exit status: 1).\n\n\n\n\n"
```

We've since learned that this is because `quickjs-wasm-sys` should only be compiled on the `wasm32-wasi` target. I've added the change to the build script to set this target specifically.

