### PR TITLE
Introduce `Javy` global

### DIFF
--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -69,8 +69,7 @@ fn test_logging() {
     let _guard = EXCLUSIVE_TEST.lock();
     let mut runner = Runner::new("logging.js");
 
-    let (output, logs) = run_with_u8s(&mut runner, 42);
-    assert_eq!(42, output);
+    let (_output, logs) = run(&mut runner, &[]);
     assert_eq!(
         "hello world from console.log\nhello world from console.error\n",
         logs.as_str(),

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -77,14 +77,14 @@ fn test_logging() {
     );
 }
 
-fn run_with_u8s(r: &mut Runner, i: u8) -> (u8, String) {
-    let (output, logs) = run(r, &i.to_le_bytes());
+fn run_with_u8s(r: &mut Runner, stdin: u8) -> (u8, String) {
+    let (output, logs) = run(r, &stdin.to_le_bytes());
     assert_eq!(1, output.len());
     (output[0], logs)
 }
 
-fn run(r: &mut Runner, i: &[u8]) -> (Vec<u8>, String) {
-    let (output, logs) = r.exec(i).unwrap();
+fn run(r: &mut Runner, stdin: &[u8]) -> (Vec<u8>, String) {
+    let (output, logs) = r.exec(stdin).unwrap();
     let logs = String::from_utf8(logs).unwrap();
     (output, logs)
 }

--- a/crates/cli/tests/sample-scripts/fib.js
+++ b/crates/cli/tests/sample-scripts/fib.js
@@ -1,5 +1,4 @@
-function fibonacci(input) {
-  var num = new Uint8Array(input)[0];
+function fibonacci(num) {
   var a = 1, b = 0, temp;
 
   while (num >= 0) {
@@ -9,9 +8,12 @@ function fibonacci(input) {
     num--;
   }
 
-  return new Uint8Array([b]).buffer;
+  return b;
 }
 
-var Shopify = {
-  main: fibonacci,
-};
+const buffer = new Uint8Array(1);
+Javy.IO.readSync(0, buffer);
+const result = fibonacci(buffer[0]);
+buffer[0] = result;
+Javy.IO.writeSync(1, buffer);
+

--- a/crates/cli/tests/sample-scripts/identity.js
+++ b/crates/cli/tests/sample-scripts/identity.js
@@ -1,5 +1,3 @@
-var Shopify = {
-  main: (i) => {
-    return i;
-  }
-}
+const buffer = new Uint8Array(1);
+Javy.IO.readSync(0, buffer);
+Javy.IO.writeSync(1, buffer);

--- a/crates/cli/tests/sample-scripts/logging.js
+++ b/crates/cli/tests/sample-scripts/logging.js
@@ -1,7 +1,2 @@
-var Shopify = {
-  main: (i) => {
-    console.log("hello world from console.log");
-    console.error("hello world from console.error");
-    return i;
-  }
-}
+console.log("hello world from console.log");
+console.error("hello world from console.error");

--- a/crates/cli/tests/sample-scripts/recursive-fib.js
+++ b/crates/cli/tests/sample-scripts/recursive-fib.js
@@ -1,14 +1,10 @@
-function main(input) {
-  const num = new Uint8Array(input)[0];
-  const output = fibonacci(num);
-  return new Uint8Array([output]).buffer;
-}
-
 function fibonacci(num) {
   if (num <= 1) return 1;
   return fibonacci(num - 1) + fibonacci(num - 2);
 }
 
-var Shopify = {
-  main,
-};
+const buffer = new Uint8Array(1);
+Javy.IO.readSync(0, buffer);
+const result = fibonacci(buffer[0]);
+buffer[0] = result;
+Javy.IO.writeSync(1, buffer);

--- a/crates/cli/tests/sample-scripts/str.js
+++ b/crates/cli/tests/sample-scripts/str.js
@@ -1,9 +1,8 @@
-var Shopify = {
-  main: (input) => {
-    const i = new TextDecoder().decode(input);
-    if (i === "hello") {
-      return new TextEncoder().encode("world").buffer;
-    }
-    throw new Error("unreachable");
-  }
+const buffer = new Uint8Array(1024);
+const n = Javy.IO.readSync(0, buffer);
+const input = new TextDecoder().decode(buffer.subarray(0, n));
+if (input !== "hello") {
+  throw new Error("unreachable");
 }
+const result = new TextEncoder().encode("world");
+Javy.IO.writeSync(1, result);

--- a/crates/cli/tests/sample-scripts/text-encoding.js
+++ b/crates/cli/tests/sample-scripts/text-encoding.js
@@ -20,8 +20,8 @@ function tests(i) {
     }
 }
 
-var Shopify = {
-    main: (i) => {
-        return new TextEncoder().encode(tests(new TextDecoder().decode(i))).buffer;
-    }
-}
+const buffer = new Uint8Array(1024);
+const n = Javy.IO.readSync(0, buffer);
+const input = new TextDecoder().decode(buffer.subarray(0, n));
+const result = tests(input)
+Javy.IO.writeSync(1, new TextEncoder().encode(result));

--- a/crates/core/prelude/io.js
+++ b/crates/core/prelude/io.js
@@ -1,0 +1,14 @@
+Javy.IO = {
+  readSync(fd, data) {
+    if (!(data instanceof Uint8Array)) {
+      throw Error("Data needs to be an Uint8Array");
+    }
+    return __javy_io_readSync(fd, data.buffer);
+  },
+  writeSync(fd, data) {
+    if (!(data instanceof Uint8Array)) {
+      throw Error("Data needs to be an Uint8Array");
+    }
+    return __javy_io_writeSync(fd, data.buffer);
+  },
+};

--- a/crates/core/prelude/io.js
+++ b/crates/core/prelude/io.js
@@ -6,13 +6,23 @@
       if (!(data instanceof Uint8Array)) {
         throw TypeError("Data needs to be an Uint8Array");
       }
-      return __javy_io_readSync(fd, data.buffer);
+      return __javy_io_readSync(
+        fd,
+        data.buffer,
+        data.byteOffset,
+        data.byteLength
+      );
     },
     writeSync(fd, data) {
       if (!(data instanceof Uint8Array)) {
         throw TypeError("Data needs to be an Uint8Array");
       }
-      return __javy_io_writeSync(fd, data.buffer);
+      return __javy_io_writeSync(
+        fd,
+        data.buffer,
+        data.byteOffset,
+        data.byteLength
+      );
     },
   };
 

--- a/crates/core/prelude/io.js
+++ b/crates/core/prelude/io.js
@@ -12,3 +12,6 @@ Javy.IO = {
     return __javy_io_writeSync(fd, data.buffer);
   },
 };
+
+Reflect.deleteProperty(globalThis, "__javy_io_readSync");
+Reflect.deleteProperty(globalThis, "__javy_io_writeSync");

--- a/crates/core/prelude/io.js
+++ b/crates/core/prelude/io.js
@@ -1,17 +1,21 @@
-Javy.IO = {
-  readSync(fd, data) {
-    if (!(data instanceof Uint8Array)) {
-      throw Error("Data needs to be an Uint8Array");
-    }
-    return __javy_io_readSync(fd, data.buffer);
-  },
-  writeSync(fd, data) {
-    if (!(data instanceof Uint8Array)) {
-      throw Error("Data needs to be an Uint8Array");
-    }
-    return __javy_io_writeSync(fd, data.buffer);
-  },
-};
+(function () {
+  const __javy_io_readSync = globalThis.__javy_io_readSync;
+  const __javy_io_writeSync = globalThis.__javy_io_writeSync;
+  globalThis.Javy.IO = {
+    readSync(fd, data) {
+      if (!(data instanceof Uint8Array)) {
+        throw TypeError("Data needs to be an Uint8Array");
+      }
+      return __javy_io_readSync(fd, data.buffer);
+    },
+    writeSync(fd, data) {
+      if (!(data instanceof Uint8Array)) {
+        throw TypeError("Data needs to be an Uint8Array");
+      }
+      return __javy_io_writeSync(fd, data.buffer);
+    },
+  };
 
-Reflect.deleteProperty(globalThis, "__javy_io_readSync");
-Reflect.deleteProperty(globalThis, "__javy_io_writeSync");
+  Reflect.deleteProperty(globalThis, "__javy_io_readSync");
+  Reflect.deleteProperty(globalThis, "__javy_io_writeSync");
+})();

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -86,8 +86,8 @@ fn inject_javy_globals(context: &Context, global: &Value) {
             context
                 .wrap_callback(|ctx, _this_arg, args| {
                     let (mut fd, data) = js_args_to_io_writer(args)?;
-                    fd.write_all(data)?;
-                    Ok(ctx.undefined_value()?)
+                    let n = fd.write(data)?;
+                    Ok(ctx.value_from_i32(n.try_into()?)?)
                 })
                 .unwrap(),
         )

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -51,7 +51,7 @@ fn js_args_to_io_writer(args: &[Value]) -> anyhow::Result<(Box<dyn Write>, &[u8]
     let offset: usize = (offset.as_f64()?.floor() as u64).try_into()?;
     let length: usize = (length.as_f64()?.floor() as u64).try_into()?;
 
-    let fd: Box<dyn Write> = match fd.as_f64()?.floor() as usize {
+    let fd: Box<dyn Write> = match fd.try_as_integer()? {
         1 => Box::new(std::io::stdout()),
         2 => Box::new(std::io::stderr()),
         _ => anyhow::bail!("Only stdout and stderr are supported"),
@@ -73,7 +73,7 @@ fn js_args_to_io_reader(args: &[Value]) -> anyhow::Result<(Box<dyn Read>, &mut [
     let offset: usize = (offset.as_f64()?.floor() as u64).try_into()?;
     let length: usize = (length.as_f64()?.floor() as u64).try_into()?;
 
-    let fd: Box<dyn Read> = match fd.as_f64()?.floor() as usize {
+    let fd: Box<dyn Read> = match fd.try_as_integer()? {
         0 => Box::new(std::io::stdin()),
         _ => anyhow::bail!("Only stdin is supported"),
     };

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -93,7 +93,7 @@ fn inject_javy_globals(context: &Context, global: &Value) {
                 .wrap_callback(|ctx, _this_arg, args| {
                     let (mut fd, data) = js_args_to_io_writer(args)?;
                     let n = fd.write(data)?;
-                    Ok(ctx.value_from_i32(n.try_into()?)?)
+                    ctx.value_from_i32(n.try_into()?)
                 })
                 .unwrap(),
         )
@@ -106,7 +106,7 @@ fn inject_javy_globals(context: &Context, global: &Value) {
                 .wrap_callback(|ctx, _this_arg, args| {
                     let (mut fd, data) = js_args_to_io_reader(args)?;
                     let n = fd.read(data)?;
-                    Ok(ctx.value_from_i32(n.try_into()?)?)
+                    ctx.value_from_i32(n.try_into()?)
                 })
                 .unwrap(),
         )

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -1,13 +1,10 @@
-mod engine;
-
 use quickjs_wasm_rs::{Context, Value};
 
 use once_cell::sync::OnceCell;
-use std::io::{self, Read};
+use std::io::{self, Read, Write};
 
-static mut JS_CONTEXT: OnceCell<Context> = OnceCell::new();
-static mut ENTRYPOINT: (OnceCell<Value>, OnceCell<Value>) = (OnceCell::new(), OnceCell::new());
-static SCRIPT_NAME: &str = "script.js";
+static mut CONTEXT: OnceCell<Context> = OnceCell::new();
+static mut CODE: OnceCell<String> = OnceCell::new();
 
 // TODO
 //
@@ -17,54 +14,77 @@ static SCRIPT_NAME: &str = "script.js";
 
 #[export_name = "wizer.initialize"]
 pub extern "C" fn init() {
+    let mut context = Context::default();
+    context
+        .register_globals(io::stderr(), io::stderr())
+        .unwrap();
+
+    context
+        .eval_global(
+            "text-encoding.js",
+            include_str!("../prelude/text-encoding.js"),
+        )
+        .unwrap();
+
+    let global = context.global_object().unwrap();
+    inject_javy_globals(&context, &global);
+
+    let mut contents = String::new();
+    io::stdin().read_to_string(&mut contents).unwrap();
+
     unsafe {
-        let mut context = Context::default();
-        context
-            .register_globals(io::stderr(), io::stderr())
-            .unwrap();
-        context
-            .eval_global(
-                "text-encoding.js",
-                include_str!("../prelude/text-encoding.js"),
-            )
-            .unwrap();
-
-        let mut contents = String::new();
-        io::stdin().read_to_string(&mut contents).unwrap();
-
-        let _ = context.eval_global(SCRIPT_NAME, &contents).unwrap();
-        let global = context.global_object().unwrap();
-        let shopify = global.get_property("Shopify").unwrap();
-        let main = shopify.get_property("main").unwrap();
-
-        JS_CONTEXT.set(context).unwrap();
-        ENTRYPOINT.0.set(shopify).unwrap();
-        ENTRYPOINT.1.set(main).unwrap();
+        CONTEXT.set(context).unwrap();
+        CODE.set(contents).unwrap();
     }
 }
 
+fn inject_javy_globals(context: &Context, global: &Value) {
+    global
+        .set_property(
+            "__javy_io_writeSync",
+            context
+                .wrap_callback(|ctx, this_arg, args| {
+                    println!("Writing");
+                    // if argc != 0 {
+                    // return context.exception_value().unwrap().into();
+                    // }
+
+                    // let mut buffer: String = String::new();
+                    // io::stdin().read_to_string(&mut buffer).unwrap();
+
+                    // let val = context.value_from_str(&buffer).unwrap();
+                    // val.into()
+                    Ok(ctx.undefined_value().unwrap())
+                })
+                .unwrap(),
+        )
+        .unwrap();
+
+    global
+        .set_property(
+            "__javy_io_readSync",
+            context
+                .wrap_callback(|ctx, this_arg, args| {
+                    println!("Reading");
+                    // if argc != 0 {
+                    // return context.exception_value().unwrap().into();
+                    // }
+
+                    // let mut buffer: String = String::new();
+                    // io::stdin().read_to_string(&mut buffer).unwrap();
+
+                    // let val = context.value_from_str(&buffer).unwrap();
+                    // val.into()
+                    Ok(ctx.undefined_value().unwrap())
+                })
+                .unwrap(),
+        )
+        .unwrap();
+}
+
 fn main() {
-    unsafe {
-        let context = JS_CONTEXT.get().unwrap();
-        let shopify = ENTRYPOINT.0.get().unwrap();
-        let main = ENTRYPOINT.1.get().unwrap();
-        let input_bytes = engine::load().expect("Couldn't load input");
+    let code = unsafe { CODE.take().unwrap() };
+    let context = unsafe { CONTEXT.take().unwrap() };
 
-        let input_value = context.array_buffer_value(&input_bytes).unwrap();
-        let output_value = main.call(shopify, &[input_value]);
-
-        if output_value.is_err() {
-            panic!("{}", output_value.unwrap_err().to_string());
-        }
-
-        let output_value = output_value.unwrap();
-        if !output_value.is_array_buffer() {
-            panic!(
-                "Only ArrayBuffers are supported as return values, a different type was returned"
-            );
-        }
-
-        let output = output_value.as_bytes().unwrap();
-        engine::store(output).expect("Couldn't store output");
-    }
+    context.eval_global("function.mjs", &code).unwrap();
 }

--- a/crates/quickjs-wasm-rs/src/js_binding/value.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/value.rs
@@ -315,6 +315,10 @@ impl Value {
     }
 }
 
+// We can't implement From<Value> for JSValue, as
+// JSValue is automatically generated and it would result
+// in a cyclic crate dependency.
+#[allow(clippy::from_over_into)]
 impl Into<JSValue> for Value {
     fn into(self) -> JSValue {
         self.value

--- a/crates/quickjs-wasm-rs/src/js_binding/value.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/value.rs
@@ -156,6 +156,19 @@ impl Value {
         }
     }
 
+    pub fn as_bytes_mut(&self) -> Result<&mut [u8]> {
+        let mut len = 0;
+        let ptr = unsafe { JS_GetArrayBuffer(self.context, &mut len, self.value) };
+        if ptr.is_null() {
+            Err(anyhow!(
+                "Can't represent {:?} as an array buffer",
+                self.value
+            ))
+        } else {
+            Ok(unsafe { std::slice::from_raw_parts_mut(ptr, len as _) })
+        }
+    }
+
     pub fn properties(&self) -> Result<Properties> {
         Properties::new(self.context, self.value)
     }

--- a/crates/quickjs-wasm-rs/src/js_binding/value.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/value.rs
@@ -114,6 +114,16 @@ impl Value {
         self.get_tag() == JS_TAG_BIG_INT
     }
 
+    pub fn as_f64(&self) -> Result<f64> {
+        if self.is_repr_as_f64() {
+            return Ok(self.as_f64_unchecked());
+        }
+        if self.is_repr_as_i32() {
+            return Ok(self.as_i32_unchecked() as f64);
+        }
+        anyhow::bail!("Value is not a number")
+    }
+
     pub fn as_bool(&self) -> Result<bool> {
         if self.is_bool() {
             Ok(self.value as i32 > 0)
@@ -275,6 +285,12 @@ impl Value {
     /// To actually retrieve the exception, we need to retrieve the exception object from the global state.
     fn as_exception(&self) -> Result<Exception> {
         Exception::new(self.context)
+    }
+}
+
+impl Into<JSValue> for Value {
+    fn into(self) -> JSValue {
+        self.value
     }
 }
 

--- a/crates/quickjs-wasm-rs/src/js_binding/value.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/value.rs
@@ -124,6 +124,20 @@ impl Value {
         anyhow::bail!("Value is not a number")
     }
 
+    pub fn try_as_integer(&self) -> Result<i32> {
+        if self.is_repr_as_f64() {
+            let v = self.as_f64_unchecked();
+            if v.trunc() != v {
+                anyhow::bail!("Value is not an integer");
+            }
+            return Ok((v as i64).try_into()?);
+        }
+        if self.is_repr_as_i32() {
+            return Ok(self.as_i32_unchecked() as i32);
+        }
+        anyhow::bail!("Value is not a number")
+    }
+
     pub fn as_bool(&self) -> Result<bool> {
         if self.is_bool() {
             Ok(self.value as i32 > 0)


### PR DESCRIPTION
This PR supersedes #129 and achieves two things

- Remove the `Shopify.main()` global and instead execute the top level code directly.
- Expose the `Javy` global, which currently contains only IO-related functions.

It might make sense to go through this PR by commit, if the overall diff is too wild.

Things I want to do after this PR:
- I saw that the `TextDecoder` and `TextEncoder` impls rely on custom `Javy` functions. I'd like to hide those (similar to how I am hiding `__javy_io_readSync` in this PR), so that people can't use them.
- Write a macro to automatically include every file in the `prelude` folder.