### PR TITLE
Parallelize CLI tests

### DIFF
--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -1,18 +1,9 @@
 mod runner;
 
-use lazy_static::lazy_static;
 use runner::Runner;
-use std::sync::Mutex;
-
-lazy_static! {
-    // We avoid running the tests concurrently since the CLI writes on disk at very specific
-    // locations, which causes the tests to be unpredictable.
-    static ref EXCLUSIVE_TEST: Mutex<()> = Mutex::default();
-}
 
 #[test]
 fn test_identity() {
-    let _guard = EXCLUSIVE_TEST.lock();
     let mut runner = Runner::default();
 
     let (output, _) = run_with_u8s(&mut runner, 42);
@@ -21,7 +12,6 @@ fn test_identity() {
 
 #[test]
 fn test_fib() {
-    let _guard = EXCLUSIVE_TEST.lock();
     let mut runner = Runner::new("fib.js");
 
     let (output, _) = run_with_u8s(&mut runner, 5);
@@ -30,7 +20,6 @@ fn test_fib() {
 
 #[test]
 fn test_recursive_fib() {
-    let _guard = EXCLUSIVE_TEST.lock();
     let mut runner = Runner::new("recursive-fib.js");
 
     let (output, _) = run_with_u8s(&mut runner, 5);
@@ -39,7 +28,6 @@ fn test_recursive_fib() {
 
 #[test]
 fn test_str() {
-    let _guard = EXCLUSIVE_TEST.lock();
     let mut runner = Runner::new("str.js");
 
     let (output, _) = run(&mut runner, "hello".as_bytes());
@@ -48,7 +36,6 @@ fn test_str() {
 
 #[test]
 fn test_encoding() {
-    let _guard = EXCLUSIVE_TEST.lock();
     let mut runner = Runner::new("text-encoding.js");
 
     let (output, _) = run(&mut runner, "hello".as_bytes());
@@ -66,7 +53,6 @@ fn test_encoding() {
 
 #[test]
 fn test_logging() {
-    let _guard = EXCLUSIVE_TEST.lock();
     let mut runner = Runner::new("logging.js");
 
     let (_output, logs) = run(&mut runner, &[]);

--- a/crates/cli/tests/runner/mod.rs
+++ b/crates/cli/tests/runner/mod.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io::{self, Cursor, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use tempfile;
 use wasi_common::pipe::{ReadPipe, WritePipe};
 use wasmtime::{Config, Engine, Linker, Module, OptLevel, Store};
 use wasmtime_wasi::sync::WasiCtxBuilder;
@@ -62,7 +63,10 @@ impl Runner {
         let wasm_file_name = format!("{}.wasm", uuid::Uuid::new_v4());
 
         let root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
-        let wasm_file = std::env::temp_dir().join(wasm_file_name);
+        // This directory is unique and will automatically get deleted
+        // when `tempdir` goes out of scope.
+        let tempdir = tempfile::tempdir().unwrap();
+        let wasm_file = tempdir.path().join(wasm_file_name);
         let js_file = root.join("tests").join("sample-scripts").join(js_file);
 
         let output = Command::new(env!("CARGO_BIN_EXE_javy"))


### PR DESCRIPTION
Cuts the execution time of the integration tests from ~120s on my machine down to ~70s.