### PR TITLE
Flush writeSync writes

### DIFF
--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -93,6 +93,7 @@ fn inject_javy_globals(context: &Context, global: &Value) {
                 .wrap_callback(|ctx, _this_arg, args| {
                     let (mut fd, data) = js_args_to_io_writer(args)?;
                     let n = fd.write(data)?;
+                    fd.flush()?;
                     ctx.value_from_i32(n.try_into()?)
                 })
                 .unwrap(),


### PR DESCRIPTION
Generally this works without the explicit `flush` but I've run into at least one situation where I was missing output on stdout and adding an explicit flush resulted in the output appearing.