### PR TITLE
Add --nocapture to quickjs-wasm-rs tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ docs:
 
 test-quickjs-wasm-rs:
 		cd crates/quickjs-wasm-rs \
-				&& cargo wasi test --features json \
+				&& cargo wasi test --features json -- --nocapture \
 				&& cd -
 
 test-core:


### PR DESCRIPTION
I needed this to actually see details about assertions that failed, otherwise I just see a Wasm trap with no details on the underlying failure.