### PR TITLE
Align text-encoding.js with pattern used in io.js

### DIFF
--- a/crates/core/prelude/text-encoding.js
+++ b/crates/core/prelude/text-encoding.js
@@ -1,54 +1,65 @@
-class TextDecoder {
-    constructor(label = "utf-8", options = {}) {
-        if (label !== "utf-8") {
-            // Not spec-compliant behaviour
-            throw new RangeError("The encoding label provided must be utf-8");
-        }
-        Object.defineProperties(this, {
-            encoding: { value: "utf-8", enumerable: true, writable: false },
-            fatal: { value: !!options.fatal, enumerable: true, writable: false },
-            ignoreBOM: { value: !!options.ignoreBOM, enumerable: true, writable: false },
-        })
-    }
+(function () {
+    const __javy_decodeUtf8BufferToString = globalThis.__javy_decodeUtf8BufferToString;
+    const __javy_encodeStringToUtf8Buffer = globalThis.__javy_encodeStringToUtf8Buffer;
 
-    decode(input, options = {}) {
-        if (input === undefined) {
-            return "";
-        }
-
-        if (options.stream) {
-            throw new Error("Streaming decode is not supported");
+    class TextDecoder {
+        constructor(label = "utf-8", options = {}) {
+            if (label !== "utf-8") {
+                // Not spec-compliant behaviour
+                throw new RangeError("The encoding label provided must be utf-8");
+            }
+            Object.defineProperties(this, {
+                encoding: { value: "utf-8", enumerable: true, writable: false },
+                fatal: { value: !!options.fatal, enumerable: true, writable: false },
+                ignoreBOM: { value: !!options.ignoreBOM, enumerable: true, writable: false },
+            })
         }
 
-        // backing buffer would not have byteOffset and may have different byteLength
-        let byteOffset = input.byteOffset || 0;
-        let byteLength = input.byteLength;
-        if (ArrayBuffer.isView(input)) {
-            input = input.buffer;
+        decode(input, options = {}) {
+            if (input === undefined) {
+                return "";
+            }
+
+            if (options.stream) {
+                throw new Error("Streaming decode is not supported");
+            }
+
+            // backing buffer would not have byteOffset and may have different byteLength
+            let byteOffset = input.byteOffset || 0;
+            let byteLength = input.byteLength;
+            if (ArrayBuffer.isView(input)) {
+                input = input.buffer;
+            }
+
+            if (!(input instanceof ArrayBuffer)) {
+                throw new TypeError("The provided value is not of type '(ArrayBuffer or ArrayBufferView)'");
+            }
+
+            // ignoreBOM does not appear to change behaviour for UTF-8
+            return __javy_decodeUtf8BufferToString(input, byteOffset, byteLength, this.fatal);
+        }
+    }
+
+    class TextEncoder {
+        constructor() {
+            Object.defineProperties(this, {
+                encoding: { value: "utf-8", enumerable: true, writable: false },
+            });
         }
 
-        if (!(input instanceof ArrayBuffer)) {
-            throw new TypeError("The provided value is not of type '(ArrayBuffer or ArrayBufferView)'");
+        encode(input) {
+            input = input.toString(); // non-string inputs are converted to strings
+            return new Uint8Array(__javy_encodeStringToUtf8Buffer(input));
         }
 
-        // ignoreBOM does not appear to change behaviour for UTF-8
-        return Javy.decodeUtf8BufferToString(input, byteOffset, byteLength, this.fatal);
-    }
-}
-
-class TextEncoder {
-    constructor() {
-        Object.defineProperties(this, {
-            encoding: { value: "utf-8", enumerable: true, writable: false },
-        });
+        encodeInto(source, destination) {
+            throw new Error("encodeInto is not supported");
+        }
     }
 
-    encode(input) {
-        input = input.toString(); // non-string inputs are converted to strings
-        return new Uint8Array(Javy.encodeStringToUtf8(input));
-    }
+    globalThis.TextDecoder = TextDecoder;
+    globalThis.TextEncoder = TextEncoder;
 
-    encodeInto(source, destination) {
-        throw new Error("encodeInto is not supported");
-    }
-}
+    Reflect.deleteProperty(globalThis, "__javy_decodeUtf8BufferToString");
+    Reflect.deleteProperty(globalThis, "__javy_encodeStringToUtf8Buffer");
+})();

--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -28,15 +28,16 @@ where
     global.set_property("console", console_object)?;
 
     let javy_object = context.object_value()?;
-    javy_object.set_property(
-        "decodeUtf8BufferToString",
+    global.set_property("Javy", javy_object)?;
+
+    global.set_property(
+        "__javy_decodeUtf8BufferToString",
         context.wrap_callback(decode_utf8_buffer_to_js_string())?,
     )?;
-    javy_object.set_property(
-        "encodeStringToUtf8",
+    global.set_property(
+        "__javy_encodeStringToUtf8Buffer",
         context.wrap_callback(encode_js_string_to_utf8_buffer())?,
     )?;
-    global.set_property("Javy", javy_object)?;
 
     global.set_property(
         "__javy_io_writeSync",


### PR DESCRIPTION
Mostly a refactor but it will hide the internal Javy methods used by text-encoding.js.