### PR TITLE
Speed up local builds

### DIFF
--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -35,7 +35,7 @@ fn copy_engine_binary() {
         engine_path = engine_path.join("target/wasm32-wasi/release/javy_core.wasm");
     }
 
-    println!("cargo:rerun-if-changed={:?}", engine_path);
+    println!("cargo:rerun-if-changed={}", engine_path.to_str().unwrap());
     println!("cargo:rerun-if-changed=build.rs");
 
     if engine_path.exists() {

--- a/crates/quickjs-wasm-sys/build.rs
+++ b/crates/quickjs-wasm-sys/build.rs
@@ -57,7 +57,7 @@ fn main() {
         .generate()
         .unwrap();
 
-    println!("cargo:rerun-if-changed=src/extensions/value.c");
+    println!("cargo:rerun-if-changed=extensions/value.c");
     println!("cargo:rerun-if-changed=wrapper.h");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());


### PR DESCRIPTION
If a `cargo:rerun-if-changed` directive refers to a file that doesn't exist, then `cargo` will always rebuild.

For `quickjs-wasm-sys`, `src/extensions/value.c` doesn't exist but `extensions/value.c` does.

For `cli`, `println!("cargo:rerun-if-changed={:?}", engine_path);` will emit
```
cargo:rerun-if-changed="/Users/jeffcharles/src/github.com/Shopify/javy/target/wasm32-wasi/release/javy_core.wasm"
```
which results in `cargo` thinking the path starts with `"` and ends with `"` so it can't find the file. 