### PR TITLE
Use wrap_callback for console_log_to

### DIFF
--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -1,11 +1,6 @@
 use anyhow::anyhow;
-use quickjs_wasm_rs::sys::{
-    ext_js_exception, ext_js_undefined, JSContext, JSValue, JS_FreeCString, JS_ToCStringLen2,
-    JS_size_t,
-};
 use quickjs_wasm_rs::{Context, Value};
 use std::borrow::Cow;
-use std::ffi::c_int;
 use std::io::{Read, Write};
 use std::str;
 
@@ -20,8 +15,8 @@ where
 {
     let global = context.global_object()?;
 
-    let console_log_callback = context.new_callback(console_log_to(log_stream))?;
-    let console_error_callback = context.new_callback(console_log_to(error_stream))?;
+    let console_log_callback = context.wrap_callback(console_log_to(log_stream))?;
+    let console_error_callback = context.wrap_callback(console_log_to(error_stream))?;
     let console_object = context.object_value()?;
     console_object.set_property("log", console_log_callback)?;
     console_object.set_property("error", console_error_callback)?;
@@ -61,32 +56,21 @@ where
 
 fn console_log_to<T>(
     mut stream: T,
-) -> impl FnMut(*mut JSContext, JSValue, c_int, *mut JSValue, c_int) -> JSValue + 'static
+) -> impl FnMut(&Context, &Value, &[Value]) -> anyhow::Result<Value>
 where
     T: Write + 'static,
 {
-    move |ctx: *mut JSContext, _this: JSValue, argc: c_int, argv: *mut JSValue, _magic: c_int| {
-        let mut len: JS_size_t = 0;
-        for i in 0..argc {
+    move |ctx: &Context, _this: &Value, args: &[Value]| {
+        for (i, arg) in args.iter().enumerate() {
             if i != 0 {
-                write!(stream, " ").unwrap();
+                write!(stream, " ")?;
             }
 
-            let str_ptr = unsafe { JS_ToCStringLen2(ctx, &mut len, *argv.offset(i as isize), 0) };
-            if str_ptr.is_null() {
-                return unsafe { ext_js_exception };
-            }
-
-            let str_ptr = str_ptr as *const u8;
-            let str_len = len as usize;
-            let buffer = unsafe { std::slice::from_raw_parts(str_ptr, str_len) };
-
-            stream.write_all(buffer).unwrap();
-            unsafe { JS_FreeCString(ctx, str_ptr as *const i8) };
+            stream.write_all(arg.as_str()?.as_bytes())?;
         }
 
-        writeln!(stream,).unwrap();
-        unsafe { ext_js_undefined }
+        writeln!(stream)?;
+        ctx.undefined_value()
     }
 }
 
@@ -208,6 +192,17 @@ mod tests {
 
         ctx.eval_global("main", "console.log(\"bonjour\", \"le\", \"monde\")")?;
         assert_eq!(b"bonjour le monde\n", stream.0.borrow().as_slice());
+
+        stream.clear();
+
+        ctx.eval_global(
+            "main",
+            "console.log(2.3, true, { foo: 'bar' }, null, undefined)",
+        )?;
+        assert_eq!(
+            b"2.3 true [object Object] null undefined\n",
+            stream.0.borrow().as_slice()
+        );
         Ok(())
     }
 
@@ -225,6 +220,17 @@ mod tests {
 
         ctx.eval_global("main", "console.error(\"bonjour\", \"le\", \"monde\")")?;
         assert_eq!(b"bonjour le monde\n", stream.0.borrow().as_slice());
+
+        stream.clear();
+
+        ctx.eval_global(
+            "main",
+            "console.error(2.3, true, { foo: 'bar' }, null, undefined)",
+        )?;
+        assert_eq!(
+            b"2.3 true [object Object] null undefined\n",
+            stream.0.borrow().as_slice()
+        );
         Ok(())
     }
 

--- a/crates/quickjs-wasm-rs/src/lib.rs
+++ b/crates/quickjs-wasm-rs/src/lib.rs
@@ -7,9 +7,6 @@ pub use crate::js_binding::value::Value;
 pub use crate::serialize::de::Deserializer;
 pub use crate::serialize::ser::Serializer;
 
-#[deprecated = "This is a hack to enable Javy Core to compile and will be removed when it's no longer necessary"]
-pub mod sys;
-
 #[cfg(feature = "messagepack")]
 pub mod messagepack;
 

--- a/crates/quickjs-wasm-rs/src/sys.rs
+++ b/crates/quickjs-wasm-rs/src/sys.rs
@@ -1,4 +1,0 @@
-pub use quickjs_wasm_sys::{
-    ext_js_exception, ext_js_undefined, size_t as JS_size_t, JSContext, JSValue, JS_FreeCString,
-    JS_ToCStringLen2,
-};


### PR DESCRIPTION
Switch `console_log_to` to use `wrap_callback` instead of `new_callback`. This lets us get rid of the `sys` re-exports from `quickjs-wasm-rs`.

I also added a test case for passing non-string values to `console.log` to check if they're transformed as expected.