### PR TITLE
Rebuild quickjs-wasm-sys if any files in quickjs dir change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,6 +1237,7 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "cc",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/quickjs-wasm-sys/Cargo.toml
+++ b/crates/quickjs-wasm-sys/Cargo.toml
@@ -14,3 +14,4 @@ categories = ["external-ffi-bindings"]
 [build-dependencies]
 cc = "1.0"
 bindgen = "0.59"
+walkdir = "2"

--- a/crates/quickjs-wasm-sys/build.rs
+++ b/crates/quickjs-wasm-sys/build.rs
@@ -1,6 +1,8 @@
 use std::env;
 use std::path::PathBuf;
 
+use walkdir::WalkDir;
+
 fn main() {
     let this_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let wasi_sdk_path =
@@ -59,6 +61,13 @@ fn main() {
 
     println!("cargo:rerun-if-changed=extensions/value.c");
     println!("cargo:rerun-if-changed=wrapper.h");
+
+    for entry in WalkDir::new("quickjs") {
+        println!(
+            "cargo:rerun-if-changed={}",
+            entry.unwrap().path().to_str().unwrap()
+        );
+    }
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings.write_to_file(out_dir.join("bindings.rs")).unwrap();


### PR DESCRIPTION
I realized we weren't triggering a rebuild if any C files changed in the sys crate. I'm leaving the file filter wide open for now, we can add more restrictions if this turns out to be a problem in practice.