### PR TITLE
Bump quickjs-wasm-sys version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-sys"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bindgen",
  "cc",

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["api-bindings"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-sys = { version = "0.1.0", path = "../quickjs-wasm-sys" }
+quickjs-wasm-sys = { version = "0.1.1", path = "../quickjs-wasm-sys" }
 rmp-serde = { version = "^0.15", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }

--- a/crates/quickjs-wasm-sys/Cargo.toml
+++ b/crates/quickjs-wasm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-sys"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 edition.workspace = true 
 license.workspace = true


### PR DESCRIPTION
We added some APIs in `quickjs-wasm-sys` that `quickjs-wasm-rs` relies on so we need to push a new version of `quickjs-wasm-sys` to crates.io before we can push a new version of `quickjs-wasm-rs`.