### PR TITLE
Add publish script to sys crate

### DIFF
--- a/crates/quickjs-wasm-sys/README.md
+++ b/crates/quickjs-wasm-sys/README.md
@@ -11,3 +11,7 @@ For example, if you install the `wasi-sdk` in `/opt/wasi-sdk`, you can run:
 ```bash
 export QUICKJS_WASM_SYS_WASI_SDK_PATH=/opt/wasi-sdk
 ```
+
+## Publishing to crates.io
+
+To publish this crate to crates.io, run `./publish.sh`.

--- a/crates/quickjs-wasm-sys/publish.sh
+++ b/crates/quickjs-wasm-sys/publish.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ -z $QUICKJS_WASM_SYS_WASI_SDK_PATH ]]; then
+    echo "QUICKJS_WASM_SYS_WASI_SDK_PATH must be set to a path with a downloaded wasi-sdk" 1>&2
+    exit 1
+fi
+
+cargo publish --target=wasm32-wasi


### PR DESCRIPTION
Add a publish script to sys crate that checks the WASI_SDK flag is set and the correct target is passed. This matches the approach used in the sys crate.