### PR TITLE
Fix encoding of unpaired surrogates and enable WPT tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: 
+on:
   push:
     branches:
       - main
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-       
+        with:
+          submodules: true
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -59,6 +60,3 @@ jobs:
 
       - name: Lint
         run: make fmt
-
-
-  

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test-wpt: cli
 			&& npm test \
 			&& cd -
 
-tests: test-quickjs-wasm-rs test-core test-cli
+tests: test-quickjs-wasm-rs test-core test-cli test-wpt
 
 fmt: fmt-quickjs-wasm-sys fmt-quickjs-wasm-rs fmt-core fmt-cli
 


### PR DESCRIPTION
Fixes failing WPT `textencoder-utf16-surrogates` tests and adds any tests we've enabled to run in CI. We replace unmatched surrogates in JS with a UTF-16 replacement char before converting to UTF-8. This does introduce a 0.0862% to 3.5610% increase in execution time as measured by our benchmarks for cases where there are no unpaired surrogates.

The code is not the cleanest JS I could have written. I tried with a cleaner looking version and I saw 10% increases in total execution time. After some experimenting and trying to optimize for cases without surrogates, I got it down to what's here. There might be some other ways to get the time spent in this function down even further.

Some other approaches I considered:
- Addressing this in Rust code but we do not have access to the underlying WTF-16 byte array in the `JSValue` we receive as an argument. QuickJS does not expose any APIs to retrieve these bytes either. So we cannot preprocess the input in Rust without adding extensions to our QuickJS implementation.
- Briefly looked at if we could post-process the output we receive back from QuickJS from invoking `JS_ToCStringLen2` and after experimenting a bit, right now I'm not confident that there's a contiguous range of output byte triples where it would be safe to replace them with a UTF-8 replacement char without unintentionally replacing valid byte triples. It may be worth that exploring that further though. 
- Adding an extension to our QuickJS code to handle the string conversion better but, I am rejecting that approach for now given the approach here is more maintainable and the impact on execution speed seems manageable to me. We could do this in the future if it makes sense to.

For cases where there are unpaired surrogates, our current encoder implementation will currently throw an exception, so the slower execution speed that would result from this change is likely better in most cases with unpaired surrogates.