### PR TITLE
Enables one suite and adds fixmes for other relevant ones

### DIFF
--- a/crates/core/prelude/text-encoding.js
+++ b/crates/core/prelude/text-encoding.js
@@ -47,7 +47,7 @@
             });
         }
 
-        encode(input) {
+        encode(input = "") {
             input = input.toString(); // non-string inputs are converted to strings
             return new Uint8Array(__javy_encodeStringToUtf8Buffer(input));
         }

--- a/wpt/custom_tests/textdecoder-fatal-streaming.any.js
+++ b/wpt/custom_tests/textdecoder-fatal-streaming.any.js
@@ -1,0 +1,46 @@
+// META: title=Encoding API: End-of-file
+
+// Copy of textdecoder-fatal-streaming with utf-16 tests commented out
+
+test(function () {
+    [
+        { encoding: 'utf-8', sequence: [0xC0] },
+        // {encoding: 'utf-16le', sequence: [0x00]},
+        // {encoding: 'utf-16be', sequence: [0x00]}
+    ].forEach(function (testCase) {
+
+        assert_throws_js(TypeError, function () {
+            var decoder = new TextDecoder(testCase.encoding, { fatal: true });
+            decoder.decode(new Uint8Array(testCase.sequence));
+        }, 'Unterminated ' + testCase.encoding + ' sequence should throw if fatal flag is set');
+
+        assert_equals(
+            new TextDecoder(testCase.encoding).decode(new Uint8Array([testCase.sequence])),
+            '\uFFFD',
+            'Unterminated UTF-8 sequence should emit replacement character if fatal flag is unset');
+    });
+}, 'Fatal flag, non-streaming cases');
+
+// test(function () {
+
+//     var decoder = new TextDecoder('utf-16le', { fatal: true });
+//     var odd = new Uint8Array([0x00]);
+//     var even = new Uint8Array([0x00, 0x00]);
+
+//     assert_equals(decoder.decode(odd, { stream: true }), '');
+//     assert_equals(decoder.decode(odd), '\u0000');
+
+//     assert_throws_js(TypeError, function () {
+//         decoder.decode(even, { stream: true });
+//         decoder.decode(odd)
+//     });
+
+//     assert_throws_js(TypeError, function () {
+//         decoder.decode(odd, { stream: true });
+//         decoder.decode(even);
+//     });
+
+//     assert_equals(decoder.decode(even, { stream: true }), '\u0000');
+//     assert_equals(decoder.decode(even), '\u0000');
+
+// }, 'Fatal flag, streaming cases');

--- a/wpt/test_spec.js
+++ b/wpt/test_spec.js
@@ -4,9 +4,55 @@ export default [
     ignoredTests: ["This is an ignored test"],
   },
   {
+    testFile: "upstream/encoding/api-basics.any.js",
+    ignoredTests: ["Decode sample: utf-16le", "Decode sample: utf-16be", "Decode sample: utf-16"],
+  },
+  // { // FIXME script importing isn't working
+  //   testFile: "upstream/encoding/api-invalid-label.any.js",
+  // },
+  // { // FIXME script importing isn't working
+  //   testFile: "upstream/encoding/api-replacement-encodings.any.js",
+  // },
+  // { // FIXME needs fix for TextEncoder to be merged
+  //   testFile: "upstream/encoding/api-surrogates-utf8.any.js",
+  // },
+  // { // FIXME requires `encodeInto` support
+  //   testFile: "upstream/encoding/encodeInto.any.js",
+  // },
+  // { // FIXME script importing isn't working
+  //   testFile: "upstream/encoding/replacement-encodings.any.js",
+  // },
+  // { // FIXME need to add streaming support
+  //   testFile: "upstream/encoding/textdecoder-arguments.any.js",
+  // },
+  // { // FIXME need to fix failing BOM test
+  //   testFile: "upstream/encoding/textdecoder-byte-order-marks.any.js",
+  //   ignoredTests: ["Byte-order marks: utf-16le", "Byte-order marks: utf-16be"],
+  // },
+  {
     testFile: "upstream/encoding/textdecoder-eof.any.js",
     ignoredTests: ["/stream: true/"],
   },
+  // { // FIXME need to fix the type of the exception thrown
+  //   testFile: "custom_tests/textdecoder-fatal-streaming.any.js",
+  // },
+  // { // FIXME need to fix the type of the exception thrown when fatal is set to `true`
+  //   testFile: "upstream/encoding/textdecoder-fatal.any.js",
+  //   ignoredTests: ["Fatal flag: utf-16le - truncated code unit"],
+  // },
+  // { // FIXME need to fix failing BOM test
+  //   testFile: "upstream/encoding/textdecoder-ignorebom.any.js",
+  //   ignoredTests: ["/utf-16/"]
+  // },
+  // { // FIXME script importing isn't working
+  //   testFile: "upstream/encoding/textdecoder-labels.any.js",
+  // },
+  // { // FIXME need to make a custom test that doesn't run non-UTF8 encodings and doesn't rely on SharedArrayBuffers
+  //   testFile: "upstream/encoding/textdecoder-streaming.any.js",
+  // },
+  // { // FIXME script importing isn't working
+  //   testFile: "upstream/encoding/textencoder-constructor-non-utf.any.js",
+  // },
   {
     testFile: "upstream/encoding/textencoder-utf16-surrogates.any.js",
   },


### PR DESCRIPTION
- Enables the API basics tests for encoding
- Adds other test suites we should enable at some point with a comment indicating why they're disabled
- Copies an existing suite that includes UTF-16 inside the test case and comments out running the UTF-16 pieces
- Adds a safe default for `.encode`'s `input` argument

I want something in the code to be able to track which suites we want to turn on. These changes don't include suites we will never turn on like ones for legacy encodings. We can tackle the script importing not working as expected separately. It's mostly trying to pull in a list of valid encodings and we only care about UTF-8 so we can maybe do something else to make those tests happy or perhaps just create custom copies of them.