### PR TITLE
Add a dylib for Javy

### DIFF
--- a/crates/cli/tests/dylib_test.rs
+++ b/crates/cli/tests/dylib_test.rs
@@ -1,0 +1,92 @@
+use anyhow::Result;
+use std::boxed::Box;
+use std::path::{Path, PathBuf};
+use std::str;
+use wasi_common::pipe::WritePipe;
+use wasmtime::{Engine, Instance, Linker, Module, Store};
+use wasmtime_wasi::{sync::WasiCtxBuilder, WasiCtx};
+
+#[test]
+fn test_dylib() -> Result<()> {
+    let engine = Engine::default();
+    let mut linker = Linker::new(&engine);
+    wasmtime_wasi::add_to_linker(&mut linker, |s| s)?;
+    let stderr = WritePipe::new_in_memory();
+    let wasi = WasiCtxBuilder::new()
+        .stderr(Box::new(stderr.clone()))
+        .build();
+    let module = create_module(&engine)?;
+
+    {
+        let mut store = Store::new(&engine, wasi);
+        let instance = linker.instantiate(&mut store, &module)?;
+        let eval_bytecode_func =
+            instance.get_typed_func::<(u32, u32), (), _>(&mut store, "eval-bytecode")?;
+
+        let js_src = "console.log(42);";
+        let (bytecode_ptr, bytecode_len) = compile_src(js_src.as_bytes(), &instance, &mut store)?;
+        eval_bytecode_func.call(&mut store, (bytecode_ptr, bytecode_len))?;
+    }
+
+    let log_output = stderr.try_into_inner().unwrap().into_inner();
+    assert_eq!("42\n", str::from_utf8(&log_output)?);
+
+    Ok(())
+}
+
+fn create_module(engine: &Engine) -> Result<Module> {
+    let mut lib_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    lib_path.pop();
+    lib_path.pop();
+    lib_path = lib_path.join(
+        Path::new("target")
+            .join("wasm32-wasi")
+            .join("release")
+            .join("javy_provider.wasm"),
+    );
+    Module::from_file(engine, lib_path)
+}
+
+fn compile_src(
+    js_src: &[u8],
+    instance: &Instance,
+    mut store: &mut Store<WasiCtx>,
+) -> Result<(u32, u32)> {
+    let memory = instance.get_memory(&mut store, "memory").unwrap();
+    let compile_src_func =
+        instance.get_typed_func::<(u32, u32, u32), u32, _>(&mut store, "compile-src")?;
+
+    let js_src_ptr = allocate_memory(&instance, &mut store, 1, js_src.len().try_into()?)?;
+    memory.write(&mut store, js_src_ptr.try_into()?, js_src)?;
+
+    let bytecode_len_ptr = allocate_memory(&instance, &mut store, 4, 1)?;
+    let bytecode_ptr = compile_src_func.call(
+        &mut store,
+        (js_src_ptr, js_src.len().try_into()?, bytecode_len_ptr),
+    )?;
+
+    let mut bytecode_len_buffer = [0; 4];
+    memory.read(
+        &mut store,
+        bytecode_ptr.try_into()?,
+        &mut bytecode_len_buffer,
+    )?;
+    let bytecode_len = u32::from_le_bytes(bytecode_len_buffer);
+
+    Ok((bytecode_ptr, bytecode_len))
+}
+
+fn allocate_memory(
+    instance: &Instance,
+    mut store: &mut Store<WasiCtx>,
+    alignment: u32,
+    new_size: u32,
+) -> Result<u32> {
+    let realloc_func = instance
+        .get_typed_func::<(u32, u32, u32, u32), u32, _>(&mut store, "canonical_abi_realloc")?;
+    let orig_ptr = 0;
+    let orig_size = 0;
+    realloc_func
+        .call(&mut store, (orig_ptr, orig_size, alignment, new_size))
+        .map_err(Into::into)
+}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,6 +9,10 @@ license.workspace = true
 name = "javy_core"
 path = "src/main.rs"
 
+[lib]
+name = "javy_provider"
+crate-type = ["cdylib"]
+
 [dependencies]
 anyhow = { workspace = true }
 quickjs-wasm-rs = { path = "../quickjs-wasm-rs" }

--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -52,6 +52,14 @@ where
             ctx.value_from_i32(n.try_into()?)
         })?,
     )?;
+
+    context.eval_global(
+        "text-encoding.js",
+        include_str!("../prelude/text-encoding.js"),
+    )?;
+
+    context.eval_global("io.js", include_str!("../prelude/io.js"))?;
+
     Ok(())
 }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,0 +1,106 @@
+use quickjs_wasm_rs::Context;
+use std::alloc::{alloc, dealloc, Layout};
+use std::io;
+use std::ptr::copy_nonoverlapping;
+use std::slice;
+use std::str;
+
+mod globals;
+
+// Unlike C's realloc, zero-length allocations need not have
+// unique addresses, so a zero-length allocation may be passed
+// in and also requested, but it's ok to return anything that's
+// non-zero to indicate success.
+const ZERO_SIZE_ALLOCATION_PTR: *mut u8 = 1 as _;
+
+/// Compiles JS source code to QuickJS bytecode.
+///
+/// Returns a pointer to a byte array containing the bytecode.
+///
+/// # Arguments
+///
+/// * `js_src_ptr` - A pointer to the start of a byte array containing UTF-8 JS source code
+/// * `js_src_len` - The length of the byte array containing JS source code
+/// * `bytecode_len_ptr` - A pointer to where to write the length of the returned bytecode byte array
+///
+/// # Safety
+///
+/// * `js_src_ptr` must reference a valid array of unsigned bytes of `js_src_len` length
+/// * `bytecode_len` must be a pointer allocated by `canonical_abi_realloc` with an `alignment` of
+///   4 and a `new_size` of 1
+#[export_name = "compile-src"]
+pub unsafe extern "C" fn compile_src(
+    js_src_ptr: *const u8,
+    js_src_len: usize,
+    bytecode_len_ptr: *mut u32,
+) -> *const u8 {
+    let context = Context::default();
+    let js_src = str::from_utf8(slice::from_raw_parts(js_src_ptr, js_src_len)).unwrap();
+    let bytecode = context.compile_global("function.mjs", js_src).unwrap();
+    *bytecode_len_ptr = bytecode.len().try_into().unwrap();
+    // We need the bytecode buffer to live longer than this function so it can be read from memory
+    Box::leak(bytecode.into_boxed_slice()).as_ptr()
+}
+
+/// Evaluates QuickJS bytecode
+///
+/// # Safety
+///
+/// * `bytecode_ptr` must reference a valid array of unsigned bytes of `bytecode_len` length
+#[export_name = "eval-bytecode"]
+pub unsafe extern "C" fn eval_src(bytecode_ptr: *const u8, bytecode_len: usize) {
+    let context = Context::default();
+    globals::inject_javy_globals(&context, io::stderr(), io::stderr()).unwrap();
+    let bytecode = slice::from_raw_parts(bytecode_ptr, bytecode_len);
+    context.eval_binary(bytecode).unwrap();
+}
+
+/// 1. Allocate memory of new_size with alignment.
+/// 2. If original_ptr != 0
+///   a. copy min(new_size, original_size) bytes from original_ptr to new memory
+///   b. de-allocate original_ptr
+/// 3. return new memory ptr
+///
+/// # Safety
+///
+/// * `original_ptr` must be 0 or a valid pointer
+/// * if `original_ptr` is not 0, it must be valid for reads of `original_size`
+///   bytes
+/// * if `original_ptr` is not 0, it must be properly aligned
+/// * if `original_size` is not 0, it must match the `new_size` value provided
+///   in the original `canonical_abi_realloc` call that returned `original_ptr`
+#[export_name = "canonical_abi_realloc"]
+pub unsafe extern "C" fn canonical_abi_realloc(
+    original_ptr: *mut u8,
+    original_size: usize,
+    alignment: usize,
+    new_size: usize,
+) -> *mut std::ffi::c_void {
+    assert!(new_size >= original_size);
+
+    let new_mem = match new_size {
+        0 => ZERO_SIZE_ALLOCATION_PTR,
+        // this call to `alloc` is safe since `new_size` must be > 0
+        _ => alloc(Layout::from_size_align(new_size, alignment).unwrap()),
+    };
+
+    if !original_ptr.is_null() && original_size != 0 {
+        copy_nonoverlapping(original_ptr, new_mem, original_size);
+        canonical_abi_free(original_ptr, original_size, alignment);
+    }
+    new_mem as _
+}
+
+/// Frees memory
+///
+/// # Safety
+///
+/// * `ptr` must denote a block of memory allocated by `canonical_abi_realloc`
+/// * `size` and `alignment` must match the values provided in the original
+///   `canonical_abi_realloc` call that returned `ptr`
+#[export_name = "canonical_abi_free"]
+pub unsafe extern "C" fn canonical_abi_free(ptr: *mut u8, size: usize, alignment: usize) {
+    if size > 0 {
+        dealloc(ptr, Layout::from_size_align(size, alignment).unwrap())
+    };
+}

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -13,17 +13,6 @@ pub extern "C" fn init() {
     let context = Context::default();
     globals::inject_javy_globals(&context, io::stderr(), io::stderr()).unwrap();
 
-    context
-        .eval_global(
-            "text-encoding.js",
-            include_str!("../prelude/text-encoding.js"),
-        )
-        .unwrap();
-
-    context
-        .eval_global("io.js", include_str!("../prelude/io.js"))
-        .unwrap();
-
     let mut contents = String::new();
     io::stdin().read_to_string(&mut contents).unwrap();
 


### PR DESCRIPTION
Adds a Wasm dynamic library that has functions for compiling JS source code to QuickJS bytecode, executing QuickJS bytecode, and two canonical ABI functions for managing memory. Also adds an integration test for exercising the library.

Optimizing the dylib with Wizer and integrating the dylib into the CLI will be in future pull requests to keep this one manageable.