### PR TITLE
Add workflow test for dylib that generates module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.55"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "arrayvec"
@@ -695,6 +695,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs-set-times"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,9 +760,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -789,10 +798,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
-name = "indexmap"
-version = "1.8.0"
+name = "idna"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -894,6 +913,7 @@ dependencies = [
  "uuid",
  "wasi-common",
  "wasm-encoder 0.20.0",
+ "wasmprinter",
  "wasmtime",
  "wasmtime-wasi",
  "which",
@@ -1123,6 +1143,12 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project-lite"
@@ -1674,6 +1700,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +1763,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +1794,17 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "uuid"
@@ -1901,6 +1968,26 @@ name = "wasmparser"
 version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+
+[[package]]
+name = "wasmparser"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adde01ade41ab9a5d10ec8ed0bb954238cf8625b5cd5a13093d6de2ad9c2be1a"
+dependencies = [
+ "indexmap",
+ "url",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.2.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3045e1aa2cac847f4f94a1e25db9f084a947aeff47d9099fb9c5ccd16d335040"
+dependencies = [
+ "anyhow",
+ "wasmparser 0.96.0",
+]
 
 [[package]]
 name = "wasmtime"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,6 +893,7 @@ dependencies = [
  "tempfile",
  "uuid",
  "wasi-common",
+ "wasm-encoder 0.20.0",
  "wasmtime",
  "wasmtime-wasi",
  "which",
@@ -1881,6 +1882,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05632e0a66a6ed8cca593c24223aabd6262f256c3693ad9822c315285f010614"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.78.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,7 +2256,7 @@ dependencies = [
  "log",
  "rayon",
  "wasi-cap-std-sync",
- "wasm-encoder",
+ "wasm-encoder 0.6.0",
  "wasmparser 0.78.2",
  "wasmtime",
  "wasmtime-wasi",

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-core:
 # Note: to make this faster, the engine should be optimized beforehand (wasm-strip + wasm-opt).
 test-cli: core
 		cd crates/cli \
-				&& cargo test --release \
+				&& cargo test --release -- --nocapture\
 				&& cd -
 
 test-wpt: cli

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,6 +29,7 @@ lazy_static = "1.4"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 criterion = "0.3"
 num-format = "0.4.3"
+wasm-encoder = "0.20"
 
 [[bench]]
 name = "benchmark"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -9,6 +9,9 @@ build = "build.rs"
 [[bin]]
 name = "javy"
 
+[features]
+dump_wat = []
+
 [dependencies]
 wizer = "1.6.0"
 which = "4.2"
@@ -30,6 +33,9 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 criterion = "0.3"
 num-format = "0.4.3"
 wasm-encoder = "0.20"
+# ideally would be optional and only included for builds with `dump_wat` enabled but cargo doesn't
+# allow that for dev dependencies
+wasmprinter = "0.2.45"
 
 [[bench]]
 name = "benchmark"

--- a/crates/cli/tests/dylib_test.rs
+++ b/crates/cli/tests/dylib_test.rs
@@ -3,8 +3,10 @@ use std::boxed::Box;
 use std::path::{Path, PathBuf};
 use std::str;
 use wasi_common::pipe::WritePipe;
-use wasmtime::{Engine, Instance, Linker, Module, Store};
+use wasmtime::{Config, Engine, Instance, Linker, Module, Store};
 use wasmtime_wasi::{sync::WasiCtxBuilder, WasiCtx};
+
+mod module_generator;
 
 #[test]
 fn test_dylib() -> Result<()> {
@@ -27,6 +29,43 @@ fn test_dylib() -> Result<()> {
         let js_src = "console.log(42);";
         let (bytecode_ptr, bytecode_len) = compile_src(js_src.as_bytes(), &instance, &mut store)?;
         eval_bytecode_func.call(&mut store, (bytecode_ptr, bytecode_len))?;
+    }
+
+    let log_output = stderr.try_into_inner().unwrap().into_inner();
+    assert_eq!("42\n", str::from_utf8(&log_output)?);
+
+    Ok(())
+}
+
+#[test]
+fn test_dylib_workflow() -> Result<()> {
+    let engine = Engine::new(Config::default().wasm_multi_memory(true))?;
+    let quickjs_provider_module = create_module(&engine)?;
+
+    let js_src = "console.log(42);";
+    let bytecode = compile_src_with_separate_instance(&engine, &quickjs_provider_module, js_src)?;
+    let wasm_module = module_generator::generate_module(bytecode, js_src)?;
+    let js_module = Module::from_binary(&engine, &wasm_module)?;
+
+    let mut linker = Linker::new(&engine);
+    wasmtime_wasi::add_to_linker(&mut linker, |s| s)?;
+    let stderr = WritePipe::new_in_memory();
+    let wasi = WasiCtxBuilder::new()
+        .stderr(Box::new(stderr.clone()))
+        .build();
+
+    // scope is needed to ensure `store` is dropped before trying to read from `stderr` below
+    {
+        let mut store = Store::new(&engine, wasi);
+        let quickjs_provider_instance = linker.instantiate(&mut store, &quickjs_provider_module)?;
+        linker.instance(
+            &mut store,
+            "javy_quickjs_provider_v1",
+            quickjs_provider_instance,
+        )?;
+        let js_instance = linker.instantiate(&mut store, &js_module)?;
+        let start_func = js_instance.get_typed_func::<(), (), _>(&mut store, "_start")?;
+        start_func.call(&mut store, ())?;
     }
 
     let log_output = stderr.try_into_inner().unwrap().into_inner();
@@ -82,4 +121,22 @@ fn allocate_memory(
     realloc_func
         .call(&mut store, (orig_ptr, orig_size, alignment, new_size))
         .map_err(Into::into)
+}
+
+fn compile_src_with_separate_instance(
+    engine: &Engine,
+    quickjs_provider_module: &Module,
+    js_src: &str,
+) -> Result<Vec<u8>> {
+    let mut linker = Linker::new(&engine);
+    wasmtime_wasi::add_to_linker(&mut linker, |s| s)?;
+    let wasi = WasiCtxBuilder::new().build();
+    let mut store = Store::new(&engine, wasi);
+    let instance = linker.instantiate(&mut store, &quickjs_provider_module)?;
+
+    let (bytecode_ptr, bytecode_len) = compile_src(js_src.as_bytes(), &instance, &mut store)?;
+    let memory = instance.get_memory(&mut store, "memory").unwrap();
+    let mut bytecode = vec![0; bytecode_len.try_into()?];
+    memory.read(&mut store, bytecode_ptr.try_into()?, &mut bytecode)?;
+    Ok(bytecode)
 }

--- a/crates/cli/tests/module_generator/mod.rs
+++ b/crates/cli/tests/module_generator/mod.rs
@@ -1,0 +1,240 @@
+use anyhow::Result;
+use wasm_encoder::{
+    CodeSection, CustomSection, DataCountSection, DataSection, EntityType, ExportKind,
+    ExportSection, Function, FunctionSection, ImportSection, Instruction, MemorySection,
+    MemoryType, Module, TypeSection, ValType,
+};
+
+pub fn generate_module(bytecode: Vec<u8>, js_src: &str) -> Result<Vec<u8>> {
+    let mut module = Module::new();
+    let mut indices = Indices::new();
+
+    add_types(&mut module, &mut indices);
+    add_imports(&mut module, &mut indices);
+    add_functions(&mut module, &mut indices);
+    add_memories(&mut module, &mut indices);
+    add_exports(&mut module, &indices);
+    add_data_count(&mut module, 1);
+    add_code(&mut module, &indices, bytecode.len().try_into()?);
+    add_data(&mut module, bytecode);
+    add_source_code(&mut module, js_src)?;
+
+    Ok(module.finish())
+}
+
+struct Indices {
+    pub realloc_ty: Option<u32>,
+    pub eval_bytecode_ty: Option<u32>,
+    pub start_ty: Option<u32>,
+    pub realloc_fn: Option<u32>,
+    pub eval_bytecode_fn: Option<u32>,
+    pub start_fn: Option<u32>,
+    pub javy_quickjs_provider_memory: Option<u32>,
+    pub memory: Option<u32>,
+    pub bytecode_data: u32,
+    next_ty_index: u32,
+    next_func_index: u32,
+    next_memory_index: u32,
+}
+
+impl Indices {
+    pub fn new() -> Indices {
+        Indices {
+            realloc_ty: None,
+            eval_bytecode_ty: None,
+            start_ty: None,
+            realloc_fn: None,
+            eval_bytecode_fn: None,
+            start_fn: None,
+            javy_quickjs_provider_memory: None,
+            memory: None,
+            bytecode_data: 0,
+            next_ty_index: 0,
+            next_func_index: 0,
+            next_memory_index: 0,
+        }
+    }
+
+    pub fn assign_realloc_ty(&mut self) {
+        self.realloc_ty = Some(self.next_ty_index);
+        self.next_ty_index += 1;
+    }
+
+    pub fn assign_eval_bytecode_ty(&mut self) {
+        self.eval_bytecode_ty = Some(self.next_ty_index);
+        self.next_ty_index += 1;
+    }
+
+    pub fn assign_start_ty(&mut self) {
+        self.start_ty = Some(self.next_ty_index);
+        self.next_ty_index += 1;
+    }
+
+    pub fn assign_realloc_fn(&mut self) {
+        self.realloc_fn = Some(self.next_func_index);
+        self.next_func_index += 1;
+    }
+
+    pub fn assign_eval_bytecode_fn(&mut self) {
+        self.eval_bytecode_fn = Some(self.next_func_index);
+        self.next_func_index += 1;
+    }
+
+    pub fn assign_start_fn(&mut self) {
+        self.start_fn = Some(self.next_func_index);
+        self.next_func_index += 1;
+    }
+
+    pub fn assign_javy_quickjs_provider_memory(&mut self) {
+        self.javy_quickjs_provider_memory = Some(self.next_memory_index);
+        self.next_memory_index += 1;
+    }
+
+    pub fn assign_memory(&mut self) {
+        self.memory = Some(self.next_memory_index);
+        self.next_memory_index += 1;
+    }
+}
+
+fn add_types(module: &mut Module, indices: &mut Indices) {
+    let mut types = TypeSection::new();
+
+    // canonical_abi_realloc
+    types.function(
+        vec![ValType::I32, ValType::I32, ValType::I32, ValType::I32],
+        vec![ValType::I32],
+    );
+    indices.assign_realloc_ty();
+
+    // eval_bytecode
+    types.function(vec![ValType::I32, ValType::I32], vec![]);
+    indices.assign_eval_bytecode_ty();
+
+    // _start
+    types.function(vec![], vec![]);
+    indices.assign_start_ty();
+
+    module.section(&types);
+}
+
+fn add_imports(module: &mut Module, indices: &mut Indices) {
+    const IMPORT_NAMESPACE: &str = "javy_quickjs_provider_v1";
+    let mut imports = ImportSection::new();
+
+    imports.import(
+        IMPORT_NAMESPACE,
+        "canonical_abi_realloc",
+        EntityType::Function(indices.realloc_ty.unwrap()),
+    );
+    indices.assign_realloc_fn();
+
+    imports.import(
+        IMPORT_NAMESPACE,
+        "eval_bytecode",
+        EntityType::Function(indices.eval_bytecode_ty.unwrap()),
+    );
+    indices.assign_eval_bytecode_fn();
+
+    imports.import(
+        IMPORT_NAMESPACE,
+        "memory",
+        EntityType::Memory(MemoryType {
+            minimum: 0,
+            maximum: None,
+            memory64: false,
+            shared: false,
+        }),
+    );
+    indices.assign_javy_quickjs_provider_memory();
+
+    module.section(&imports);
+}
+
+fn add_functions(module: &mut Module, indices: &mut Indices) {
+    let mut functions = FunctionSection::new();
+    functions.function(indices.start_ty.unwrap());
+    indices.assign_start_fn();
+    module.section(&functions);
+}
+
+fn add_memories(module: &mut Module, indices: &mut Indices) {
+    let mut memories = MemorySection::new();
+    memories.memory(MemoryType {
+        minimum: 0,
+        maximum: None,
+        memory64: false,
+        shared: false,
+    });
+    indices.assign_memory();
+    module.section(&memories);
+}
+
+fn add_exports(module: &mut Module, indices: &Indices) {
+    let mut exports = ExportSection::new();
+    exports.export("memory", ExportKind::Memory, indices.memory.unwrap());
+    exports.export("_start", ExportKind::Func, indices.start_fn.unwrap());
+    module.section(&exports);
+}
+
+fn add_data_count(module: &mut Module, count: u32) {
+    module.section(&DataCountSection { count });
+}
+
+fn add_code(module: &mut Module, indices: &Indices, bytecode_len: i32) {
+    let mut code = CodeSection::new();
+
+    let mut start_function = Function::new_with_locals_types([ValType::I32]);
+    const ALLOCATED_PTR_LOCAL_INDEX: u32 = 0;
+
+    // allocate memory in javy_quickjs_provider for bytecode array
+    start_function.instruction(&Instruction::I32Const(0)); // orig ptr
+    start_function.instruction(&Instruction::I32Const(0)); // orig size
+    start_function.instruction(&Instruction::I32Const(1)); // alignment
+    start_function.instruction(&Instruction::I32Const(bytecode_len)); // new_size
+    start_function.instruction(&Instruction::Call(indices.realloc_fn.unwrap()));
+
+    // copy bytecode array into allocated memory
+    start_function.instruction(&Instruction::LocalTee(ALLOCATED_PTR_LOCAL_INDEX)); // set local to allocated ptr, also sets allocated ptr as dest addr for mem init
+    start_function.instruction(&Instruction::I32Const(0)); // offset into data segment
+    start_function.instruction(&Instruction::I32Const(bytecode_len)); // size to copy from data segment
+
+    // top-2: dest addr, top-1: offset into source, top-0: size of memory region in bytes
+    start_function.instruction(&Instruction::MemoryInit {
+        mem: indices.javy_quickjs_provider_memory.unwrap(),
+        data_index: indices.bytecode_data,
+    });
+    start_function.instruction(&Instruction::DataDrop(indices.bytecode_data)); // no longer need data section so reduce memory pressure
+
+    // evaluate bytecode
+    start_function.instruction(&Instruction::LocalGet(ALLOCATED_PTR_LOCAL_INDEX)); // bytecode_ptr
+    start_function.instruction(&Instruction::I32Const(bytecode_len));
+    start_function.instruction(&Instruction::Call(indices.eval_bytecode_fn.unwrap())); // eval_bytecode
+    start_function.instruction(&Instruction::End);
+
+    code.function(&start_function);
+    module.section(&code);
+}
+
+fn add_data(module: &mut Module, bytecode: Vec<u8>) {
+    let mut data = DataSection::new();
+    data.passive(bytecode);
+    module.section(&data);
+}
+
+fn add_source_code(module: &mut Module, js_src: &str) -> Result<()> {
+    let mut compressed_source_code: Vec<u8> = vec![];
+    brotli::enc::BrotliCompress(
+        &mut std::io::Cursor::new(js_src.as_bytes()),
+        &mut compressed_source_code,
+        &brotli::enc::BrotliEncoderParams {
+            quality: 11,
+            ..Default::default()
+        },
+    )?;
+    let source_code_custom = CustomSection {
+        name: "javy_source",
+        data: &compressed_source_code,
+    };
+    module.section(&source_code_custom);
+    Ok(())
+}

--- a/crates/cli/tests/module_generator/mod.rs
+++ b/crates/cli/tests/module_generator/mod.rs
@@ -5,6 +5,7 @@ use wasm_encoder::{
     MemoryType, Module, TypeSection, ValType,
 };
 
+// Run the calling code with the `dump_wat` feature enabled to print the WAT to stdout
 pub fn generate_module(bytecode: Vec<u8>, js_src: &str) -> Result<Vec<u8>> {
     let mut module = Module::new();
     let mut indices = Indices::new();
@@ -19,7 +20,16 @@ pub fn generate_module(bytecode: Vec<u8>, js_src: &str) -> Result<Vec<u8>> {
     add_data(&mut module, bytecode);
     add_source_code(&mut module, js_src)?;
 
-    Ok(module.finish())
+    let wasm_binary = module.finish();
+
+    if cfg!(feature = "dump_wat") {
+        println!(
+            "Generated WAT: \n{}",
+            wasmprinter::print_bytes(&wasm_binary)?
+        );
+    }
+
+    Ok(wasm_binary)
 }
 
 struct Indices {

--- a/crates/cli/tests/module_generator/mod.rs
+++ b/crates/cli/tests/module_generator/mod.rs
@@ -7,6 +7,7 @@ use wasm_encoder::{
 
 // Run the calling code with the `dump_wat` feature enabled to print the WAT to stdout
 //
+// For the example generated WAT, the `bytecode_len` is 67
 // (module
 //     (type (;0;) (func (param i32 i32 i32 i32) (result i32)))
 //     (type (;1;) (func (param i32 i32)))

--- a/crates/cli/tests/module_generator/mod.rs
+++ b/crates/cli/tests/module_generator/mod.rs
@@ -6,6 +6,35 @@ use wasm_encoder::{
 };
 
 // Run the calling code with the `dump_wat` feature enabled to print the WAT to stdout
+//
+// (module
+//     (type (;0;) (func (param i32 i32 i32 i32) (result i32)))
+//     (type (;1;) (func (param i32 i32)))
+//     (type (;2;) (func))
+//     (import "javy_quickjs_provider_v1" "canonical_abi_realloc" (func (;0;) (type 0)))
+//     (import "javy_quickjs_provider_v1" "eval_bytecode" (func (;1;) (type 1)))
+//     (import "javy_quickjs_provider_v1" "memory" (memory (;0;) 0))
+//     (func (;2;) (type 2)
+//         (local i32)
+//         i32.const 0
+//         i32.const 0
+//         i32.const 1
+//         i32.const 67
+//         call 0
+//         local.tee 0
+//         i32.const 0
+//         i32.const 67
+//         memory.init 0
+//         data.drop 0
+//         local.get 0
+//         i32.const 67
+//         call 1
+//     )
+//     (memory (;1;) 0)
+//     (export "memory" (memory 1))
+//     (export "_start" (func 2))
+//     (data (;0;) "\02\03\0econsole\06log\18function.mjs\0e\00\06\00\a0\01\00\01\00\03\00\00\11\01\a2\01\00\00\008\de\00\00\00B\df\00\00\00\bd*$\01\00\cd(\c0\03\01\00")
+// )
 pub fn generate_module(bytecode: Vec<u8>, js_src: &str) -> Result<Vec<u8>> {
     let mut module = Module::new();
     let mut indices = Indices::new();


### PR DESCRIPTION
Adds another integration test that exercises the dylib. This time we compile the source code to bytecode in an isolated instance of the `javy_quickjs_provider.wasm` dylib. Then we generate a Wasm module using `wasm_encoder` containing a series of instructions to execute QuickJS bytecode that's been stored in a data section. This is more reflective of how the CLI and runtime environments will use the dylib.

I tried a few different approaches for how to structure the module generation to avoid relying on hard-coded indices as much as possible. I opted for the one here since it just introduces a single, not complicated abstraction to achieve that outcome. I could probably do something fancier with macros but this seems like a good enough start for now.