### PR TITLE
Update GH actions actions to use v3 instead of v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Tests + Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -24,7 +24,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: Cargo Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-cargo
 
       - name: Cargo Target Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: target
           key: ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.toml') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     name: Compile Core
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -27,7 +27,7 @@ jobs:
         run: make core
 
       - name: Upload core binary to artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: engine
           path: target/wasm32-wasi/release/javy_core.wasm
@@ -56,9 +56,9 @@ jobs:
             shasum_cmd: sha256sum
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: engine
           path: crates/cli/
@@ -83,7 +83,7 @@ jobs:
         run: gzip -k -f ${{ matrix.path }} && mv ${{ matrix.path }}.gz ${{ matrix.asset_name }}.gz
 
       - name: Upload assets to artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.asset_name }}.gz
           path: ${{ matrix.asset_name }}.gz
@@ -102,7 +102,7 @@ jobs:
         run: ${{ matrix.shasum_cmd }} ${{ matrix.asset_name }}.gz | awk '{ print $1 }' > ${{ matrix.asset_name }}.gz.sha256
 
       - name: Upload asset hash to artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.asset_name }}.gz.sha256
           path: ${{ matrix.asset_name }}.gz.sha256


### PR DESCRIPTION
This should hopefully get rid of a bunch of deprecation warnings.

Currently seeing the following on our CI runs:
<img width="2098" alt="Screenshot 2023-01-17 at 13 40 24" src="https://user-images.githubusercontent.com/154890/212983752-c6ff3b89-83eb-41fc-8af5-2e589e4104a1.png">

[actions/upload-release-asset](https://github.com/actions/upload-release-asset) also appears to be unmaintained so we'll have to replace that with something else.