### PR TITLE
Remove install Rust steps from Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: default
-          toolchain: stable
-          default: true
-          components: clippy, rustfmt
-
       - name: Cargo Cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,14 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: default
-          toolchain: stable
-          target: wasm32-wasi
-          default: true
-
       - name: Install wasi-sdk
         run: make download-wasi-sdk
 
@@ -66,13 +58,6 @@ jobs:
       - name: ls
         run: ls -R
         working-directory: crates/cli/
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: default
-          toolchain: 1.53.0
-          default: true
 
       - name: Build CLI ${{ matrix.os }}
         env:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "stable"
+components = ["clippy", "rustfmt"]
+targets = ["wasm32-wasi"]
+profile = "default"


### PR DESCRIPTION
Looks like the `actions-rs/toolchain` Github action [is no longer maintained](https://www.reddit.com/r/rust/comments/vyx4oj/actionsrs_organization_became_unmaintained/) and is raising deprecation warnings. We _should_ be able to just use `rust-toolchain.toml` to configure our toolchain in Github Actions.