### PR TITLE
Wizen javy_quickjs_provider.wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install cargo-wasi
         run: cargo install cargo-wasi
 
+      - name: Install wizer
+        run: cargo install wizer --all-features
+
       - name: Install wasi-sdk
         run: make download-wasi-sdk
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Install wasi-sdk
         run: make download-wasi-sdk
 
+      - name: Install wizer
+        run: cargo install wizer --all-features
+
       - name: Make core
         run: make core
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ cli: core
 core:
 		cd crates/core \
 				&& cargo build --release --target=wasm32-wasi \
+				&& wizer ../../target/wasm32-wasi/release/javy_quickjs_provider.wasm --allow-wasi -o ../../target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm \
 				&& cd -
 
 docs:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Javy is a beta project and will be under major development. We welcome feedback,
 - wasmtime-cli, can be installed via `cargo install wasmtime-cli` (required for
   `cargo-wasi`)
 - cargo-wasi, can be installed via `cargo install cargo-wasi`
+- wizer, can be installed via `cargo install wizer --all-features`
 
 ## Building
 

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -10,7 +10,7 @@ pub fn create_quickjs_provider_module(engine: &Engine) -> Result<Module> {
         Path::new("target")
             .join("wasm32-wasi")
             .join("release")
-            .join("javy_quickjs_provider.wasm"),
+            .join("javy_quickjs_provider_wizened.wasm"),
     );
     Module::from_file(engine, lib_path)
 }


### PR DESCRIPTION
I opted to use a fresh context in `compile_src` to avoid any weirdness with changes in a wizened context interfering with how bytecode is generated or interpreted. I tested and it doesn't make any difference right now, but seems like something that could be easy to make a mistake with in the future and the slight delay with initializing a context at compile time should be fine. Any dynamically linked modules generated will require a wizened javy_quickjs_provider to execute however.