### PR TITLE
Update binaryen to get rid of spurious warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,17 +120,15 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "binaryen"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783bea139d75b6a565b13fab54d12ec4d58724a9458598ad7283d578f4f8777a"
+source = "git+https://github.com/pepyakin/binaryen-rs#00c98174843f957681ba0bc5cdcc9d15f5d0cb23"
 dependencies = [
  "binaryen-sys",
 ]
 
 [[package]]
 name = "binaryen-sys"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e9636d01b92f2df45dce29c35a9e3724687c1055bb4472fb4b829cc4a5a561"
+version = "0.12.1"
+source = "git+https://github.com/pepyakin/binaryen-rs#00c98174843f957681ba0bc5cdcc9d15f5d0cb23"
 dependencies = [
  "cc",
  "cmake",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,7 +18,7 @@ which = "4.2"
 structopt = "0.3"
 anyhow = { workspace = true }
 tempfile = "3.2.0"
-binaryen = "0.12.0"
+binaryen = { git = "https://github.com/pepyakin/binaryen-rs" }
 parity-wasm = { version = "0.45.0", features = ["bulk"] }
 brotli = "3.3.4"
 wasm-encoder = "0.20"


### PR DESCRIPTION
Gets rid of spurious `warning: unknown name subsection with id 9 at ...` warning message when compiling a statically linked module.

This does introduce a Git dependency for the CLI which would block us from publishing it to crates.io. I've opened https://github.com/pepyakin/binaryen-rs/issues/64 to ask the maintainer to publish a new version to crates.io.