### PR TITLE
Enable textdecoder-fatal-streaming WPT suite

### DIFF
--- a/wpt/custom_tests/textdecoder-fatal-streaming.any.js
+++ b/wpt/custom_tests/textdecoder-fatal-streaming.any.js
@@ -21,26 +21,26 @@ test(function () {
     });
 }, 'Fatal flag, non-streaming cases');
 
-// test(function () {
+test(function () {
 
-//     var decoder = new TextDecoder('utf-16le', { fatal: true });
-//     var odd = new Uint8Array([0x00]);
-//     var even = new Uint8Array([0x00, 0x00]);
+    var decoder = new TextDecoder('utf-16le', { fatal: true });
+    var odd = new Uint8Array([0x00]);
+    var even = new Uint8Array([0x00, 0x00]);
 
-//     assert_equals(decoder.decode(odd, { stream: true }), '');
-//     assert_equals(decoder.decode(odd), '\u0000');
+    assert_equals(decoder.decode(odd, { stream: true }), '');
+    assert_equals(decoder.decode(odd), '\u0000');
 
-//     assert_throws_js(TypeError, function () {
-//         decoder.decode(even, { stream: true });
-//         decoder.decode(odd)
-//     });
+    assert_throws_js(TypeError, function () {
+        decoder.decode(even, { stream: true });
+        decoder.decode(odd)
+    });
 
-//     assert_throws_js(TypeError, function () {
-//         decoder.decode(odd, { stream: true });
-//         decoder.decode(even);
-//     });
+    assert_throws_js(TypeError, function () {
+        decoder.decode(odd, { stream: true });
+        decoder.decode(even);
+    });
 
-//     assert_equals(decoder.decode(even, { stream: true }), '\u0000');
-//     assert_equals(decoder.decode(even), '\u0000');
+    assert_equals(decoder.decode(even, { stream: true }), '\u0000');
+    assert_equals(decoder.decode(even), '\u0000');
 
-// }, 'Fatal flag, streaming cases');
+}, 'Fatal flag, streaming cases');

--- a/wpt/test_spec.js
+++ b/wpt/test_spec.js
@@ -33,9 +33,10 @@ export default [
     testFile: "upstream/encoding/textdecoder-eof.any.js",
     ignoredTests: ["/stream: true/"],
   },
-  // { // FIXME need to fix the type of the exception thrown
-  //   testFile: "custom_tests/textdecoder-fatal-streaming.any.js",
-  // },
+  {
+    testFile: "custom_tests/textdecoder-fatal-streaming.any.js",
+    ignoredTests: ["Fatal flag, streaming cases"]
+  },
   {
     testFile: "upstream/encoding/textdecoder-fatal.any.js",
     ignoredTests: ["Fatal flag: utf-16le - truncated code unit"],


### PR DESCRIPTION
This is a custom suite that excludes UTF-16 cases