### PR TITLE
Fix publish workflow and add test plan

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,10 @@
+# One approach to testing changes to this is:
+# 1. fork this repo to your personal account
+# 2. go into the repo settings on your fork, go to _Actions_, go to _General_, under _Workflow permissions_, select _Read and Write permissions_, then _Save_
+# 3. add your fork as a new remote and push your branch to it
+# 4. publish a release in your personal fork with the target of the release set to the branch with your changes
+# 5. confirm the workflow completes and that assets are attached to the release as expected
+
 name: Publish
 
 on:
@@ -67,7 +74,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: provider
-          path: crates/cli/
+          path: target/wasm32-wasi/release/
 
       - name: ls
         run: ls -R


### PR DESCRIPTION
Fixes the publish workflow and adds a test plan as a comment.

There are a bunch of things I want to fix up beyond what's in here but this is the bare minimum to get the workflow working as well as a test plan that will reduce the probability of this happening in the future.