### PR TITLE
Build artifacts for Apple Silicon

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,22 +49,35 @@ jobs:
         include:
           - name: linux
             os: ubuntu-latest
-            path: target/release/javy
+            path: target/x86_64-unknown-linux-gnu/release/javy
             asset_name: javy-x86_64-linux-${{ github.event.release.tag_name }}
             shasum_cmd: sha256sum
+            target: x86_64-unknown-linux-gnu
           - name: macos
             os: macos-latest
-            path: target/release/javy
+            path: target/x86_64-apple-darwin/release/javy
             asset_name: javy-x86_64-macos-${{ github.event.release.tag_name }}
             shasum_cmd: shasum -a 256
+            target: x86_64-apple-darwin
+          - name: macos-arm
+            os: macos-latest
+            path: target/aarch64-apple-darwin/release/javy
+            asset_name: javy-arm-macos-${{ github.event.release.tag_name }}
+            shasum_cmd: shasum -a 256
+            target: aarch64-apple-darwin
           - name: windows
             os: windows-latest
-            path: target\release\javy.exe
+            path: target\x86_64-pc-windows-msvc\release\javy.exe
             asset_name: javy-x86_64-windows-${{ github.event.release.tag_name }}
             shasum_cmd: sha256sum
+            target: x86_64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v3
+
+      # Should no-op except for macos-arm case where that target won't be installed
+      - name: Install target
+        run: rustup target add ${{ matrix.target }}
 
       - uses: actions/download-artifact@v3
         with:
@@ -83,7 +96,7 @@ jobs:
       - name: Build CLI ${{ matrix.os }}
         env:
           JAVY_ENGINE_PATH: javy_core.wasm
-        run: cargo build --release --package javy
+        run: cargo build --release --target ${{ matrix.target }} --package javy
 
       - name: Archive assets
         run: gzip -k -f ${{ matrix.path }} && mv ${{ matrix.path }}.gz ${{ matrix.asset_name }}.gz

--- a/README.md
+++ b/README.md
@@ -132,15 +132,4 @@ git tag v0.2.0
 git push origin --tags
 ```
 2. Create a new release from the new tag in github [here](https://github.com/Shopify/javy/releases/new).
-3. A GitHub Action will trigger for `publish.yml` when a release is published ([i.e. it doesn't run on drafts](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#:~:text=created%2C%20edited%2C%20or%20deleted%20activity%20types%20for%20draft%20releases)), creating the artifacts for downloading. However this does not currently support `arm-macos`, ie. M1 Macs.
-4. Manually build this on a m1 mac
-
-```
-gzip -k -f target/release/javy && mv target/release/javy.gz javy-arm-macos-v0.2.0.gz
-
-```
-5. Manually create the shasum file
-```
-shasum -a 256 javy-arm-macos-v0.2.0.gz | awk '{ print $1 }' > javy-arm-macos-v0.2.0.gz.sha256
-```
-6.  Attach both files to the new release page
+3. A GitHub Action will trigger for `publish.yml` when a release is published ([i.e. it doesn't run on drafts](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#:~:text=created%2C%20edited%2C%20or%20deleted%20activity%20types%20for%20draft%20releases)), creating the artifacts for downloading.


### PR DESCRIPTION
Uses cross-compilation to build an Apple Silicon binary as well.

I could probably rewrite this in such a way that only Apple Silicon has the explicit target but that introduces a bunch of conditional logic and this approach doesn't. And I prefer having fewer conditionals. But I can update if someone has a strong feeling the other way.

I also wasn't able to test the built artifact since our binaries aren't notarized. But that also seems to be the case with our manually built software. We should consider addressing that separately.