### PR TITLE
chore: Move back to stable rust

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,5 @@
 [toolchain]
-# FIXME
-# https://github.com/Shopify/javy/issues/218
-channel = "1.66.0"
+channel = "stable"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-wasi"]
 profile = "default"


### PR DESCRIPTION
Closes https://github.com/Shopify/javy/issues/218

After https://github.com/Shopify/javy/pull/217 landed, we no longer need to pin Rust to 1.66. Even though we use `cargo-wasi` for tests, it shouldn't be a problem since the builds are not optimized, so `wasm-opt` never gets invoked.