### PR TITLE
Fix publish to upload wizened artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: provider
-          path: target/wasm32-wasi/release/javy_quickjs_provider.wasm
+          path: target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm
 
       - name: Archive wizened quickjs_provider
         run: gzip -k -f target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm && mv target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm.gz javy-quickjs_provider.wasm.gz


### PR DESCRIPTION
I think the change in https://github.com/Shopify/javy/pull/205/files#diff-18497b72a2306fc2560475e2548cfe1b96b6206c395380437ba1fafefd66e126 introduced the problem. Currently testing in my personal fork to check that this fixes the issue before merging and cutting another release.