### PR TITLE
Remove ext_js_exception from quickjs-wasm-sys

### DIFF
--- a/crates/quickjs-wasm-sys/extensions/value.c
+++ b/crates/quickjs-wasm-sys/extensions/value.c
@@ -77,5 +77,4 @@ const JSValue ext_js_null = JS_NULL;
 const JSValue ext_js_undefined = JS_UNDEFINED;
 const JSValue ext_js_false = JS_FALSE;
 const JSValue ext_js_true = JS_TRUE;
-const JSValue ext_js_exception = JS_EXCEPTION;
 const JSValue ext_js_uninitialized = JS_UNINITIALIZED;

--- a/crates/quickjs-wasm-sys/src/extensions/value.rs
+++ b/crates/quickjs-wasm-sys/src/extensions/value.rs
@@ -13,6 +13,5 @@ extern "C" {
     pub static ext_js_undefined: JSValue;
     pub static ext_js_false: JSValue;
     pub static ext_js_true: JSValue;
-    pub static ext_js_exception: JSValue;
     pub static ext_js_uninitialized: JSValue;
 }


### PR DESCRIPTION
We no longer need this in Javy and returning `ext_js_exception` from a `new_callback` closure does not work correctly anyway. Invoke `JS_ThrowInternalError` instead.