### PR TITLE
Enable promises behind a feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ cli: core
 
 core:
 		cd crates/core \
-				&& cargo build --release --target=wasm32-wasi \
+				&& cargo build --release --target=wasm32-wasi --features=$(CORE_FEATURES) \
 				&& wizer ../../target/wasm32-wasi/release/javy_quickjs_provider.wasm --allow-wasi --wasm-bulk-memory true -o ../../target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm \
 				&& cd -
 
@@ -38,7 +38,7 @@ test-core:
 # Note: to make this faster, the engine should be optimized beforehand (wasm-strip + wasm-opt).
 test-cli: core
 		cd crates/cli \
-				&& cargo test --release -- --nocapture\
+				&& cargo test --release --features=$(CLI_FEATURES) -- --nocapture \
 				&& cd -
 
 test-wpt: cli

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,6 +11,7 @@ name = "javy"
 
 [features]
 dump_wat = ["dep:wasmprinter"]
+experimental_event_loop = []
 
 [dependencies]
 wizer = "1.6.0"

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -70,6 +70,7 @@ fn test_readme_script() {
     assert_eq!(r#"{"foo":3,"newBar":"baz!"}"#.as_bytes(), output);
 }
 
+#[cfg(feature = "experimental_event_loop")]
 #[test]
 fn test_promises() {
     let mut runner = Runner::new("promise.js");

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -70,6 +70,14 @@ fn test_readme_script() {
     assert_eq!(r#"{"foo":3,"newBar":"baz!"}"#.as_bytes(), output);
 }
 
+#[test]
+fn test_promises() {
+    let mut runner = Runner::new("promise.js");
+
+    let (output, _) = run(&mut runner, &[]);
+    assert_eq!("\"foo\"\"bar\"".as_bytes(), output);
+}
+
 fn run_with_u8s(r: &mut Runner, stdin: u8) -> (u8, String) {
     let (output, logs) = run(r, &stdin.to_le_bytes());
     assert_eq!(1, output.len());

--- a/crates/cli/tests/sample-scripts/promise.js
+++ b/crates/cli/tests/sample-scripts/promise.js
@@ -1,0 +1,14 @@
+(async function () {
+    function writeOutput(output) {
+        const encodedOutput = new TextEncoder().encode(JSON.stringify(output));
+        const buffer = new Uint8Array(encodedOutput);
+        // Stdout file descriptor
+        const fd = 1;
+        Javy.IO.writeSync(fd, buffer);
+    }
+
+    let promise1 = Promise.resolve("foo");
+    let v = await promise1;
+    writeOutput(v);
+    Promise.resolve("bar").then(writeOutput);
+})();

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -17,3 +17,6 @@ crate-type = ["cdylib"]
 anyhow = { workspace = true }
 quickjs-wasm-rs = { path = "../quickjs-wasm-rs" }
 once_cell = { workspace = true }
+
+[features]
+experimental_event_loop = []

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -28,5 +28,7 @@ fn main() {
     let context = unsafe { CONTEXT.take().unwrap() };
 
     context.eval_binary(&bytecode).unwrap();
-    context.execute_pending().unwrap();
+    if cfg!(feature = "experimental_event_loop") {
+        context.execute_pending().unwrap();
+    }
 }

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -28,4 +28,5 @@ fn main() {
     let context = unsafe { CONTEXT.take().unwrap() };
 
     context.eval_binary(&bytecode).unwrap();
+    context.execute_pending().unwrap();
 }


### PR DESCRIPTION
The feature is off by default. It can be enabled by running `make cli CORE_FEATURES=experimental_event_loop` and tests can be run by invoking `make test-cli CORE_FEATURES=experimental_event_loop CLI_FEATURES=experimental_event_loop`.