### PR TITLE
Use release for fmt-cli to improve CI stability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,12 @@ fmt-core:
 				&& cargo clippy --target=wasm32-wasi -- -D warnings \
 				&& cd -
 
+# Use `--release` on CLI clippy to align with `test-cli`.
+# This reduces the size of the target directory which improves CI stability.
 fmt-cli:
 		cd crates/cli/ \
 				&& cargo fmt -- --check \
-				&& cargo clippy -- -D warnings \
+				&& cargo clippy --release -- -D warnings \
 				&& cd -
 
 clean: clean-wasi-sdk clean-cargo


### PR DESCRIPTION
Locally this reduced the size of the target directory from 7.1 GB to 2.2 GB. I'd expect a similar reduction in Github's CI.

We may still need to flush the target cache in Github Actions after getting this in to get CI working reliably again.  