### PR TITLE
Use --all-targets flag for Clippy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,13 +63,13 @@ fmt-quickjs-wasm-sys:
 fmt-quickjs-wasm-rs:
 		cd crates/quickjs-wasm-rs/ \
 				&& cargo fmt -- --check \
-				&& cargo clippy --target=wasm32-wasi -- -D warnings \
+				&& cargo clippy --target=wasm32-wasi --all-targets -- -D warnings \
 				&& cd -
 
 fmt-core:
 		cd crates/core/ \
 				&& cargo fmt -- --check \
-				&& cargo clippy --target=wasm32-wasi -- -D warnings \
+				&& cargo clippy --target=wasm32-wasi --all-targets -- -D warnings \
 				&& cd -
 
 # Use `--release` on CLI clippy to align with `test-cli`.
@@ -77,7 +77,7 @@ fmt-core:
 fmt-cli:
 		cd crates/cli/ \
 				&& cargo fmt -- --check \
-				&& cargo clippy --release -- -D warnings \
+				&& cargo clippy --release --all-targets -- -D warnings \
 				&& cd -
 
 clean: clean-wasi-sdk clean-cargo

--- a/crates/cli/tests/dylib_test.rs
+++ b/crates/cli/tests/dylib_test.rs
@@ -45,7 +45,7 @@ fn compile_src(
     let compile_src_func =
         instance.get_typed_func::<(u32, u32), u32, _>(&mut store, "compile_src")?;
 
-    let js_src_ptr = allocate_memory(&instance, &mut store, 1, js_src.len().try_into()?)?;
+    let js_src_ptr = allocate_memory(instance, store, 1, js_src.len().try_into()?)?;
     memory.write(&mut store, js_src_ptr.try_into()?, js_src)?;
 
     let ret_ptr = compile_src_func.call(&mut store, (js_src_ptr, js_src.len().try_into()?))?;

--- a/crates/cli/tests/dynamic_linking_test.rs
+++ b/crates/cli/tests/dynamic_linking_test.rs
@@ -66,7 +66,7 @@ fn create_dynamically_linked_wasm_module(js_src: &str) -> Result<Vec<u8>> {
     js_file.write_all(js_src.as_bytes())?;
     let output = Command::new(env!("CARGO_BIN_EXE_javy"))
         .arg("compile")
-        .arg(&js_path.to_str().unwrap())
+        .arg(js_path.to_str().unwrap())
         .arg("-o")
         .arg(wasm_path.to_str().unwrap())
         .arg("-d")

--- a/crates/cli/tests/runner/mod.rs
+++ b/crates/cli/tests/runner/mod.rs
@@ -3,7 +3,6 @@ use std::fs;
 use std::io::{self, Cursor, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use tempfile;
 use wasi_common::pipe::{ReadPipe, WritePipe};
 use wasmtime::{Config, Engine, Linker, Module, OptLevel, Store};
 use wasmtime_wasi::sync::WasiCtxBuilder;
@@ -41,13 +40,12 @@ impl StoreContext {
         let wasi_output = WritePipe::new_in_memory();
         let log_stream = WritePipe::new_in_memory();
         wasi.set_stdout(Box::new(wasi_output.clone()));
-        wasi.set_stdin(Box::new(ReadPipe::from(input.clone())));
+        wasi.set_stdin(Box::new(ReadPipe::from(input)));
         wasi.set_stderr(Box::new(log_stream.clone()));
         Self {
             wasi,
             wasi_output,
             log_stream,
-            ..Default::default()
         }
     }
 }

--- a/crates/quickjs-wasm-rs/src/js_binding/properties.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/properties.rs
@@ -73,7 +73,7 @@ mod tests {
     fn test_keys() -> Result<()> {
         let contents = "globalThis.o = {a: 1, b: 2, c: [1, 2, 3]};";
         let context = Context::default();
-        context.eval_global("script", &contents)?;
+        context.eval_global("script", contents)?;
         let global = context.global_object()?;
         let o = global.get_property("o")?;
 
@@ -94,7 +94,7 @@ mod tests {
     fn test_values() -> Result<()> {
         let contents = "globalThis.o = {a: 1, b: 2, c: [1, 2, 3]};";
         let context = Context::default();
-        context.eval_global("script", &contents)?;
+        context.eval_global("script", contents)?;
         let global = context.global_object()?;
         let o = global.get_property("o")?;
 

--- a/crates/quickjs-wasm-rs/src/serialize/de.rs
+++ b/crates/quickjs-wasm-rs/src/serialize/de.rs
@@ -245,16 +245,14 @@ mod tests {
     fn test_null() {
         let context = Context::default();
         let val = context.null_value().unwrap();
-        let actual = deserialize_value::<()>(val);
-        assert_eq!((), actual);
+        deserialize_value::<()>(val);
     }
 
     #[test]
     fn test_undefined() {
         let context = Context::default();
         let val = context.undefined_value().unwrap();
-        let actual = deserialize_value::<()>(val);
-        assert_eq!((), actual);
+        deserialize_value::<()>(val);
     }
 
     #[test]

--- a/crates/quickjs-wasm-rs/src/serialize/mod.rs
+++ b/crates/quickjs-wasm-rs/src/serialize/mod.rs
@@ -163,9 +163,7 @@ mod tests {
 
     #[test]
     fn test_sequence() {
-        let mut expected = Vec::new();
-        expected.push("hello".to_string());
-        expected.push("world".to_string());
+        let expected = vec!["hello".to_string(), "world".to_string()];
 
         let actual = do_roundtrip::<_, Vec<String>>(&expected);
 
@@ -175,12 +173,8 @@ mod tests {
     #[test]
     fn test_nested_sequences() {
         let mut expected = Vec::new();
-        let mut a = Vec::new();
-        a.push("foo".to_string());
-        a.push("bar".to_string());
-        let mut b = Vec::new();
-        b.push("toto".to_string());
-        b.push("tata".to_string());
+        let a = vec!["foo".to_string(), "bar".to_string()];
+        let b = vec!["toto".to_string(), "tata".to_string()];
         expected.push(a);
         expected.push(b);
 

--- a/crates/quickjs-wasm-rs/src/serialize/ser.rs
+++ b/crates/quickjs-wasm-rs/src/serialize/ser.rs
@@ -596,9 +596,7 @@ mod tests {
         let context = Context::default();
         let mut serializer = ValueSerializer::from_context(&context).unwrap();
 
-        let mut sequence = Vec::new();
-        sequence.push("hello");
-        sequence.push("world");
+        let sequence = vec!["hello", "world"];
 
         sequence.serialize(&mut serializer).unwrap();
 


### PR DESCRIPTION
This should help us keep Javy test and benchmarking code more clean and readable by adding some additional static analysis.