### PR TITLE
Use package flag in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,82 +8,61 @@ install:
 	cargo install --path crates/cli
 
 bench: cli
-		cd crates/cli && cargo bench && cd -
+	cargo bench --package=javy
 
 check-bench:
-		cd crates/cli && cargo check --release --benches && cd -
+	cargo check --package=javy --release --benches
 
 cli: core
-		cd crates/cli && cargo build --release && cd -
+	cargo build --package=javy --release
 
 core:
-		cd crates/core \
-				&& cargo build --release --target=wasm32-wasi --features=$(CORE_FEATURES) \
-				&& wizer ../../target/wasm32-wasi/release/javy_quickjs_provider.wasm --allow-wasi --wasm-bulk-memory true -o ../../target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm \
-				&& cd -
+	cargo build --package=javy-core --release --target=wasm32-wasi --features=$(CORE_FEATURES) \
+		&& wizer target/wasm32-wasi/release/javy_quickjs_provider.wasm --allow-wasi --wasm-bulk-memory true -o target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm
 
 docs:
-		cd crates/core \
-				&& cargo doc --open --target=wasm32-wasi \
-				&& cd -
+	cargo doc --package=javy --open && cargo doc --package=javy-core --open --target=wasm32-wasi
 
 test-quickjs-wasm-rs:
-		cd crates/quickjs-wasm-rs \
-				&& cargo wasi test --features json -- --nocapture \
-				&& cd -
+	cargo wasi test --package=quickjs-wasm-rs --features json -- --nocapture
 
 test-core:
-		cd crates/core \
-				&& cargo wasi test -- --nocapture \
-				&& cd -
+	cargo wasi test --package=javy-core -- --nocapture
 
 # Test in release mode to skip some debug assertions
 # Note: to make this faster, the engine should be optimized beforehand (wasm-strip + wasm-opt).
 test-cli: core
-		cd crates/cli \
-				&& cargo test --release --features=$(CLI_FEATURES) -- --nocapture \
-				&& cd -
+	cargo test --package=javy --release --features=$(CLI_FEATURES) -- --nocapture
 
 test-wpt: cli
-		cd wpt \
-			&& npm install \
-			&& npm test \
-			&& cd -
+	npm install --prefix wpt && npm test --prefix wpt 
 
 tests: test-quickjs-wasm-rs test-core test-cli test-wpt
 
 fmt: fmt-quickjs-wasm-sys fmt-quickjs-wasm-rs fmt-core fmt-cli
 
 fmt-quickjs-wasm-sys:
-		cd crates/quickjs-wasm-sys/ \
-				&& cargo fmt -- --check \
-				&& cargo clippy --target=wasm32-wasi --all-targets -- -D warnings \
-				&& cd -
+	cargo fmt --package=quickjs-wasm-sys -- --check \
+		&& cargo clippy --package=quickjs-wasm-sys --target=wasm32-wasi --all-targets -- -D warnings
 
 fmt-quickjs-wasm-rs:
-		cd crates/quickjs-wasm-rs/ \
-				&& cargo fmt -- --check \
-				&& cargo clippy --target=wasm32-wasi --all-targets -- -D warnings \
-				&& cd -
+	cargo fmt --package=quickjs-wasm-rs -- --check \
+		&& cargo clippy --package=quickjs-wasm-rs --target=wasm32-wasi --all-targets -- -D warnings
 
 fmt-core:
-		cd crates/core/ \
-				&& cargo fmt -- --check \
-				&& cargo clippy --target=wasm32-wasi --all-targets -- -D warnings \
-				&& cd -
+	cargo fmt --package=javy-core -- --check \
+		&& cargo clippy --package=javy-core --target=wasm32-wasi --all-targets -- -D warnings
 
 # Use `--release` on CLI clippy to align with `test-cli`.
 # This reduces the size of the target directory which improves CI stability.
 fmt-cli:
-		cd crates/cli/ \
-				&& cargo fmt -- --check \
-				&& cargo clippy --release --all-targets -- -D warnings \
-				&& cd -
+	cargo fmt --package=javy -- --check \
+		&& cargo clippy --package=javy --release --all-targets -- -D warnings
 
 clean: clean-wasi-sdk clean-cargo
 
 clean-cargo:
-		cargo clean
+	cargo clean
 
 clean-wasi-sdk:
-		rm -r crates/quickjs-wasm-sys/wasi-sdk 2> /dev/null || true
+	rm -r crates/quickjs-wasm-sys/wasi-sdk 2> /dev/null || true


### PR DESCRIPTION
This change has us use the `--package` flag instead of `cd ... && ... && cd -` pattern. I find this reduces noise in the Makefile. I also updated the `npm` commands to use the `--prefix` flag to avoid having to change directories. I also updated the `docs` target to generate and open docs for both the CLI and Javy Core instead of just Javy Core.