### PR TITLE
Return error when JS_Eval fails

### DIFF
--- a/crates/cli/src/opt.rs
+++ b/crates/cli/src/opt.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Error, Result};
+use anyhow::{anyhow, bail, Error, Result};
 use binaryen::{CodegenConfig, Module};
 use std::path::Path;
 use wizer::Wizer;
@@ -25,7 +25,8 @@ impl<'a> Optimizer<'a> {
             .allow_wasi(true)?
             .inherit_stdio(true)
             .wasm_bulk_memory(true)
-            .run(self.wasm)?;
+            .run(self.wasm)
+            .map_err(|_| anyhow!("JS compilation failed"))?;
 
         if self.optimize {
             let codegen_cfg = CodegenConfig {

--- a/crates/quickjs-wasm-rs/src/js_binding/context.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/context.rs
@@ -79,6 +79,8 @@ impl Context {
                 JS_EVAL_FLAG_COMPILE_ONLY as i32,
             )
         };
+        // returns err with details if JS_Eval fails
+        Value::new(self.inner, raw)?;
 
         let mut output_size = 0;
         unsafe {
@@ -431,6 +433,16 @@ mod tests {
             42,
             ctx.global_object()?.get_property("foo")?.try_as_integer()?
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_compile_errors_when_invalid_using_syntax() -> Result<()> {
+        let ctx = Context::default();
+        let contents = "await foo;";
+        let res = ctx.compile_global(SCRIPT_NAME, contents);
+        let err = res.unwrap_err();
+        assert!(err.to_string().starts_with("Uncaught SyntaxError"));
         Ok(())
     }
 


### PR DESCRIPTION
This addresses a bug where using a top-level `await` or an `import` statement causes a panic when running the generated module at runtime complaining that the `BYTECODE` `oncecell` isn't set. That error message isn't particularly helpful.

I've introduced a check on the return value of `JS_Eval` by converting it into a `quickjs-wasm-rs` value which checks if it's an exception and returns an error if it is. That causes `compile_global` to return an error on failure. On both the static and dynamic linking paths, the returned result from `compile_global` is unwrapped triggering a panic with details in the error being written to stderr. The contents of the error string contain relevant details of the error.

I've also updated the error messages in the static and dynamic paths to reflect that JS compilation failed instead of dumping a Wasm stacktrace.

As an example, before changing the error message, error output on the dynamic path would look like:

```
Error: wasm trap: wasm `unreachable` instruction executed
wasm backtrace:
    0: 0x18090 - <unknown>!rust_panic
note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable to may show more debugging information
```

which is not helpful compared to `Error: JS compilation failed`.

I also needed to inherit stderr when using dynamic linking so the error message would be written to stderr, otherwise it's not output anywhere.

Another oddity that I found was that `OnceCell`'s `set` method would return `Ok` but its `take` method would return `Err` right after when calling `set` with an empty vector. That behaviour was unexpected for me. But that was occurring as a side-effect of returning an `Ok(vec![])` when `compile_global` fails so that shouldn't be an issue given that empty JS files still emit QuickJS bytecode.

I also want to call out that the QuickJS error messages aren't the best in the top-level await and import scenarios. But at least it indicates there's a syntax error and what line the syntax error is on.

When using an `import` statement:

```js
import 'foo';
```

```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Uncaught SyntaxError: expecting '('
    at function.mjs:1
', crates/core/src/main.rs:18:20
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: JS compilation failed
Error: Couldn't create wasm from input
```

and when using a top-level `await` statement:

```js
await hello();
```

```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Uncaught SyntaxError: expecting ';'
    at function.mjs:1
', crates/core/src/main.rs:18:20
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: JS compilation failed
Error: Couldn't create wasm from input
```

These were the same error messages emitted when using `qjsc`.