### PR TITLE
Merge in node win32 fixes

### DIFF
--- a/npm/javy-cli/index.js
+++ b/npm/javy-cli/index.js
@@ -133,6 +133,9 @@ function platarch() {
 		case "arm64":
 			arch = "arm";
 			break;
+		// A 32 bit arch likely needs that someone has 32bit Node installed on a
+		// 64 bit system, and wasmtime doesn't support 32bit anyway.
+		case "ia32":
 		case "x64":
 			arch = "x86_64";
 			break;

--- a/npm/javy-cli/package-lock.json
+++ b/npm/javy-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "javy-cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "javy-cli",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "cachedir": "^2.3.0",

--- a/npm/javy-cli/package.json
+++ b/npm/javy-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javy-cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This makes the `main` branch contain the changes of the currently published `javy-cli` NPM module