### PR TITLE
Add Arm64/Linux to javy-cli

### DIFF
--- a/npm/javy-cli/index.js
+++ b/npm/javy-cli/index.js
@@ -107,6 +107,7 @@ function binaryUrl(version) {
 }
 
 const SUPPORTED_TARGETS = [
+	"arm-linux",
 	"arm-macos",
 	"x86_64-macos",
 	"x86_64-windows",


### PR DESCRIPTION
Enable using `javy-cli` on Arm64 Linux to run Javy.

Wait until https://github.com/Shopify/javy/pull/257 is merged and a release is performed with all assets attached before merging this PR and publishing a new version of `javy-cli`.