### PR TITLE
Use older version of Linux for building assets

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -84,13 +84,13 @@ jobs:
       matrix:
         include:
           - name: linux
-            os: ubuntu-latest
+            os: ubuntu-20.04 # Use oldest supported non-deprecated version so we link against older glibc version which allows running binary on a wider set of Linux systems
             path: target/x86_64-unknown-linux-gnu/release/javy
             asset_name: javy-x86_64-linux-${{ github.event.release.tag_name }}
             shasum_cmd: sha256sum
             target: x86_64-unknown-linux-gnu
           - name: linux-arm64
-            os: ubuntu-latest
+            os: ubuntu-20.04 # Use oldest supported non-deprecated version so we link against older glibc version which allows running binary on a wider set of Linux systems
             path: target/aarch64-unknown-linux-gnu/release/javy
             asset_name: javy-arm-linux-${{ github.event.release.tag_name }}
             shasum_cmd: sha256sum


### PR DESCRIPTION
Using the `...-unknown-linux-gnu` targets means Javy is dynamically linked against `glibc`. Linking against a more recent version of `glibc` means that Javy cannot run on systems with an older version of `glibc`. Linking against an older version of `glibc` means Javy can run with that version and newer versions of `glibc` which is better for compatibility on Linux systems. Building on a system with an older version of `glibc` is the recommended way to go about increasing compability.

An alternative approach would be to use the `...-unknown-linux-musl` targets which are statically linked. Those targets are Tier 2 with Host tools which means they'll build but not guaranteed to produce a working build whereas the GNU targets are Tier 1. I think using an older supported version of Ubuntu doesn't introduce any downsides except for having to bump the image version when Github deprecates a given version so that's the approach I'm going with.