### PR TITLE
Remove spaces from status check names

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   compile_core:
-    name: Compile Core
+    name: compile_core
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
         run: gh release upload ${{ github.event.release.tag_name }} javy-quickjs_provider.wasm.gz.sha256
 
   compile_cli:
-    name: Compile CLI
+    name: compile_cli-${{ matrix.name }}
     needs: compile_core
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci-npm-javy-cli.yml
+++ b/.github/workflows/ci-npm-javy-cli.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: npm test
+    name: npm_test-${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   checks:
-    name: Tests + Lint
+    name: tests_and_lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We have some tooling for managing making status checks required but that tooling does not work with status checks that have spaces in them. So let's remove the spaces.