### PR TITLE
v0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "binaryen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
This version will include evaluating code as a module instead of as a global and the Linux binaries will be dynamically linked against older versions of `glibc` which should allow it to run on a wider variety of Linux systems.