### PR TITLE
Use common logic for executing bytecode and pending jobs

### DIFF
--- a/crates/core/src/execution.rs
+++ b/crates/core/src/execution.rs
@@ -1,0 +1,10 @@
+use anyhow::Result;
+use quickjs_wasm_rs::Context;
+
+pub fn run_bytecode(context: &Context, bytecode: &[u8]) -> Result<()> {
+    context.eval_binary(bytecode)?;
+    if cfg!(feature = "experimental_event_loop") {
+        context.execute_pending()?;
+    }
+    Ok(())
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -6,6 +6,7 @@ use std::ptr::copy_nonoverlapping;
 use std::slice;
 use std::str;
 
+mod execution;
 mod globals;
 
 // Unlike C's realloc, zero-length allocations need not have
@@ -62,7 +63,7 @@ pub unsafe extern "C" fn compile_src(js_src_ptr: *const u8, js_src_len: usize) -
 pub unsafe extern "C" fn eval_bytecode(bytecode_ptr: *const u8, bytecode_len: usize) {
     let context = CONTEXT.get().unwrap();
     let bytecode = slice::from_raw_parts(bytecode_ptr, bytecode_len);
-    context.eval_binary(bytecode).unwrap();
+    execution::run_bytecode(context, bytecode).unwrap();
 }
 
 /// 1. Allocate memory of new_size with alignment.

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -3,6 +3,7 @@ use quickjs_wasm_rs::Context;
 use std::io::{self, Read};
 use std::string::String;
 
+mod execution;
 mod globals;
 
 static mut CONTEXT: OnceCell<Context> = OnceCell::new();
@@ -26,9 +27,5 @@ pub extern "C" fn init() {
 fn main() {
     let bytecode = unsafe { BYTECODE.take().unwrap() };
     let context = unsafe { CONTEXT.take().unwrap() };
-
-    context.eval_binary(&bytecode).unwrap();
-    if cfg!(feature = "experimental_event_loop") {
-        context.execute_pending().unwrap();
-    }
+    execution::run_bytecode(&context, &bytecode).unwrap();
 }


### PR DESCRIPTION
I noticed we're only running pending jobs if the module is statically compiled and not if we dynamically compile. I think it makes sense to use the same logic for both paths for evaluating bytecode and running pending jobs or erroring if there are any present.

This introduces a new module in Javy Core to contain that shared logic.