### PR TITLE
Error if there are pending items on the event queue

### DIFF
--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -80,6 +80,19 @@ fn test_promises() {
     assert_eq!("\"foo\"\"bar\"".as_bytes(), output);
 }
 
+#[cfg(not(feature = "experimental_event_loop"))]
+#[test]
+fn test_promises() {
+    use crate::runner::RunnerError;
+
+    let mut runner = Runner::new("promise.js");
+    let res = runner.exec(&[]);
+    let err = res.err().unwrap().downcast::<RunnerError>().unwrap();
+    assert!(str::from_utf8(&err.stderr)
+        .unwrap()
+        .contains("Adding tasks to the event queue is not supported"));
+}
+
 #[test]
 fn test_producers_section_present() {
     let runner = Runner::new("readme.js");

--- a/crates/core/src/execution.rs
+++ b/crates/core/src/execution.rs
@@ -1,10 +1,19 @@
-use anyhow::Result;
+use std::env;
+
+use anyhow::{bail, Result};
 use quickjs_wasm_rs::Context;
 
 pub fn run_bytecode(context: &Context, bytecode: &[u8]) -> Result<()> {
     context.eval_binary(bytecode)?;
     if cfg!(feature = "experimental_event_loop") {
         context.execute_pending()?;
+    } else if context.is_pending() && !is_running_wpt_suite() {
+        // WPT enqueues a promise as part of its suite setup and we can't change that behaviour so don't error
+        bail!("Adding tasks to the event queue is not supported");
     }
     Ok(())
+}
+
+fn is_running_wpt_suite() -> bool {
+    env::var("JAVY_WPT").is_ok()
 }

--- a/crates/quickjs-wasm-rs/src/js_binding/context.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/context.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use once_cell::sync::Lazy;
 use quickjs_wasm_sys::{
     ext_js_null, ext_js_undefined, JSCFunctionData, JSClassDef, JSClassID, JSContext, JSValue,
-    JS_Eval, JS_ExecutePendingJob, JS_GetGlobalObject, JS_GetRuntime, JS_NewArray,
+    JS_Eval, JS_ExecutePendingJob, JS_GetGlobalObject, JS_GetRuntime, JS_IsJobPending, JS_NewArray,
     JS_NewArrayBufferCopy, JS_NewBigInt64, JS_NewBool_Ext, JS_NewCFunctionData, JS_NewClass,
     JS_NewClassID, JS_NewContext, JS_NewFloat64_Ext, JS_NewInt32_Ext, JS_NewInt64_Ext,
     JS_NewObject, JS_NewObjectClass, JS_NewRuntime, JS_NewStringLen, JS_NewUint32_Ext,
@@ -112,6 +112,13 @@ impl Context {
 
     pub fn eval_binary(&self, bytecode: &[u8]) -> Result<Value> {
         self.value_from_bytecode(bytecode)?.eval_function()
+    }
+
+    pub fn is_pending(&self) -> bool {
+        unsafe {
+            let runtime = JS_GetRuntime(self.inner);
+            JS_IsJobPending(runtime) == 1
+        }
     }
 
     pub fn execute_pending(&self) -> Result<()> {
@@ -639,6 +646,32 @@ mod tests {
             "Uncaught InternalError: Error containing  - truncated due to null byte\n    at <eval> (main)\n",
             err.to_string()
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_is_pending_returns_false_when_nothing_is_pending() -> Result<()> {
+        let ctx = Context::default();
+        ctx.eval_global("main", "const x = 42;")?;
+        assert!(!ctx.is_pending());
+        Ok(())
+    }
+
+    #[test]
+    fn test_is_pending_returns_true_when_pending() -> Result<()> {
+        let ctx = Context::default();
+        ctx.eval_global(
+            "main",
+            "
+async function foo() {
+    const x = 42;
+}
+(async function() {
+    await foo();
+})();
+        ",
+        )?;
+        assert!(ctx.is_pending());
         Ok(())
     }
 }

--- a/wpt/package.json
+++ b/wpt/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "bundle": "rollup -c rollup.config.js runner.js",
     "javy": "../target/release/javy compile -o bundle.wasm bundle.js",
-    "wasmtime": "wasmtime bundle.wasm",
+    "wasmtime": "wasmtime --env JAVY_WPT=1 bundle.wasm",
     "test": "npm run bundle && npm run javy && npm run wasmtime"
   },
   "devDependencies": {

--- a/wpt/test_spec.js
+++ b/wpt/test_spec.js
@@ -19,9 +19,9 @@ export default [
   // { // FIXME requires `encodeInto` support
   //   testFile: "upstream/encoding/encodeInto.any.js",
   // },
-  {
-    testFile: "upstream/encoding/replacement-encodings.any.js",
-  },
+  // { // FIXME requires the event loop
+  //   testFile: "upstream/encoding/replacement-encodings.any.js",
+  // },
   {
     testFile: "custom_tests/textdecoder-arguments.any.js",
   },


### PR DESCRIPTION
We've received feedback that the current behaviour of successfully exiting when items there are items enqueued on to the event loop that will never be executed is unexpected and they would prefer if the execution trapped with a helpful error message instead. This PR:
- Adds an `is_pending` to `Context` to return whether there are pending jobs on the event queue
- Changes the run bytecode logic to panic if there are pending jobs on the event queue with an exception if we're running the Web Platform Tests suite as the suite enqueues a promise as part of its setup
- Disables a WPT suite that enqueues events

The check if we're running the WPT suite is done through a WASI environment variable. I opted to use this approach because:
- I couldn't figure out a reasonable way to change how we run the WPT suite so that it doesn't enqueue the promise
- we won't have to use a special build of Javy for the WPT suite
- we don't have to touch the Javy CLI including adding support for additional arguments or env vars and plumbing it through to the core logic

I did take a look at the benchmarks to see if the WASI call to retrieve the env var value would have a performance impact and the results indicated no change in performance between main and this branch.