### PR TITLE
Reduce the number of host calls when logging

### DIFF
--- a/crates/cli/benches/benchmark.rs
+++ b/crates/cli/benches/benchmark.rs
@@ -108,7 +108,7 @@ impl FunctionCase {
         let wasi = WasiCtxBuilder::new()
             .stdin(Box::new(ReadPipe::from(&self.payload[..])))
             .stdout(Box::new(WritePipe::new_in_memory()))
-            .inherit_stderr()
+            .stderr(Box::new(WritePipe::new_in_memory()))
             .build();
         wasmtime_wasi::add_to_linker(&mut linker, |s| s).unwrap();
         let mut store = Store::new(&self.engine, wasi);
@@ -145,6 +145,15 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 FunctionCase::new(
                     Path::new("benches/functions/complex_discount"),
                     Path::new("dist/function.js"),
+                    &compilation,
+                    linking,
+                )
+                .unwrap(),
+            );
+            function_cases.push(
+                FunctionCase::new(
+                    Path::new("benches/functions/logging"),
+                    Path::new("index.js"),
                     &compilation,
                     linking,
                 )

--- a/crates/cli/benches/functions/logging/index.js
+++ b/crates/cli/benches/functions/logging/index.js
@@ -1,0 +1,3 @@
+for (let i = 0; i < 100; i++) {
+    console.error("Here is", "some test", "logs");
+}

--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -70,15 +70,18 @@ where
     T: Write + 'static,
 {
     move |ctx: &Context, _this: &Value, args: &[Value]| {
+        // write full string to in-memory destination before writing to stream since each write call to the stream
+        // will invoke a hostcall
+        let mut log_line = String::new();
         for (i, arg) in args.iter().enumerate() {
             if i != 0 {
-                write!(stream, " ")?;
+                log_line.push(' ');
             }
 
-            stream.write_all(arg.as_str()?.as_bytes())?;
+            log_line.push_str(arg.as_str()?);
         }
 
-        writeln!(stream)?;
+        writeln!(stream, "{log_line}")?;
         ctx.undefined_value()
     }
 }

--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -70,9 +70,8 @@ where
     T: Write + 'static,
 {
     move |ctx: &Context, _this: &Value, args: &[Value]| {
-    // Write full string to in-memory destination before writing to stream since each write call to the stream
-    // will invoke a hostcall.
-    ```
+        // Write full string to in-memory destination before writing to stream since each write call to the stream
+        // will invoke a hostcall.
         let mut log_line = String::new();
         for (i, arg) in args.iter().enumerate() {
             if i != 0 {

--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -70,8 +70,9 @@ where
     T: Write + 'static,
 {
     move |ctx: &Context, _this: &Value, args: &[Value]| {
-        // write full string to in-memory destination before writing to stream since each write call to the stream
-        // will invoke a hostcall
+    // Write full string to in-memory destination before writing to stream since each write call to the stream
+    // will invoke a hostcall.
+    ```
         let mut log_line = String::new();
         for (i, arg) in args.iter().enumerate() {
             if i != 0 {


### PR DESCRIPTION
While investigating something related to failures when calling `console.error`, I noticed our current implementation is making more host calls than necessary when writing logs. Each call to `write` on `stream` will invoke a host call since writes to the stderr stream are not buffered.

This change ensures we only make one one host call when invoking `console.error` which should improve runtime performance.