### PR TITLE
Ignore some warnings coming from the QuickJS C files

### DIFF
--- a/crates/quickjs-wasm-sys/build.rs
+++ b/crates/quickjs-wasm-sys/build.rs
@@ -47,6 +47,8 @@ fn main() {
         .flag_if_supported("-Wno-cast-function-type")
         .flag_if_supported("-Wno-implicit-fallthrough")
         .flag_if_supported("-Wno-enum-conversion")
+        .flag_if_supported("-Wno-implicit-function-declaration")
+        .flag_if_supported("-Wno-implicit-const-int-float-conversion")
         .target("wasm32-wasi")
         .opt_level(2)
         .compile("quickjs");


### PR DESCRIPTION
```warning: quickjs/quickjs.c:1689:12: warning: implicit declaration of function 'malloc_usable_size' is invalid in C99 [-Wimplicit-function-declaration]
warning:     return malloc_usable_size(ptr);
warning:            ^
warning: quickjs/quickjs.c:10742:30: warning: implicit conversion from 'long long' to 'double' changes value from 9223372036854775807 to 9223372036854775808 [-Wimplicit-const-int-float-conversion]
warning:                 else if (d > INT64_MAX)
warning:                            ~ ^~~~~~~~~
warning: /Users/jackson/src/github.com/Shopify/javy/crates/quickjs-wasm-sys/wasi-sdk/share/wasi-sysroot/include/stdint.h:46:21: note: expanded from macro 'INT64_MAX'
warning: #define INT64_MAX  (0x7fffffffffffffff)
warning:                     ^~~~~~~~~~~~~~~~~~
warning: 2 warnings generated.
```

Any reason we shouldn't ignore these warnings?