### PR TITLE
Don't panic on WriteZero in console.log/error

### DIFF
--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -64,6 +64,14 @@ fn test_logging() {
 }
 
 #[test]
+fn test_logging_with_limited_capacity() {
+    let mut runner = Runner::new_with_fixed_logging_capacity("logging.js", 2);
+
+    let (_output, logs) = run(&mut runner, &[]);
+    assert_eq!("he", logs.as_str());
+}
+
+#[test]
 fn test_readme_script() {
     let mut runner = Runner::new("readme.js");
 


### PR DESCRIPTION
When the destination buffer is full, I've noticed our `console.log` and `console.error` implementation will throw an exception. This is because the `write` operation returns `Ok(0)` which part of the Rust std lib translates into an `IOError` with a `kind` of `WriteZero` and in our `console` code, that causes us to return the error which causes `wrap_callback` to throw a JS exception.

This isn't desirable behaviour because sometimes the `stderr` stream will have a hard capacity limit. This PR has our `console` implementation ignore `WriteZero` errors.

I've opted to only ignore `WriteZero` errors for now because there may be a more appropriate fix for other kinds of I/O errors should they occur and ignoring all errors makes it more difficult to find the cause of any other unexpected that may come up around logging.