### PR TITLE
Remove no longer necessary '&&'s from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,12 @@ cli: core
 	cargo build --package=javy --release
 
 core:
-	cargo build --package=javy-core --release --target=wasm32-wasi --features=$(CORE_FEATURES) \
-		&& wizer target/wasm32-wasi/release/javy_quickjs_provider.wasm --allow-wasi --wasm-bulk-memory true -o target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm
+	cargo build --package=javy-core --release --target=wasm32-wasi --features=$(CORE_FEATURES)
+	wizer target/wasm32-wasi/release/javy_quickjs_provider.wasm --allow-wasi --wasm-bulk-memory true -o target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm
 
 docs:
-	cargo doc --package=javy --open && cargo doc --package=javy-core --open --target=wasm32-wasi
+	cargo doc --package=javy --open
+	cargo doc --package=javy-core --open --target=wasm32-wasi
 
 test-quickjs-wasm-rs:
 	cargo wasi test --package=quickjs-wasm-rs --features json -- --nocapture
@@ -35,29 +36,30 @@ test-cli: core
 	cargo test --package=javy --release --features=$(CLI_FEATURES) -- --nocapture
 
 test-wpt: cli
-	npm install --prefix wpt && npm test --prefix wpt 
+	npm install --prefix wpt
+	npm test --prefix wpt 
 
 tests: test-quickjs-wasm-rs test-core test-cli test-wpt
 
 fmt: fmt-quickjs-wasm-sys fmt-quickjs-wasm-rs fmt-core fmt-cli
 
 fmt-quickjs-wasm-sys:
-	cargo fmt --package=quickjs-wasm-sys -- --check \
-		&& cargo clippy --package=quickjs-wasm-sys --target=wasm32-wasi --all-targets -- -D warnings
+	cargo fmt --package=quickjs-wasm-sys -- --check
+	cargo clippy --package=quickjs-wasm-sys --target=wasm32-wasi --all-targets -- -D warnings
 
 fmt-quickjs-wasm-rs:
-	cargo fmt --package=quickjs-wasm-rs -- --check \
-		&& cargo clippy --package=quickjs-wasm-rs --target=wasm32-wasi --all-targets -- -D warnings
+	cargo fmt --package=quickjs-wasm-rs -- --check
+	cargo clippy --package=quickjs-wasm-rs --target=wasm32-wasi --all-targets -- -D warnings
 
 fmt-core:
-	cargo fmt --package=javy-core -- --check \
-		&& cargo clippy --package=javy-core --target=wasm32-wasi --all-targets -- -D warnings
+	cargo fmt --package=javy-core -- --check
+	cargo clippy --package=javy-core --target=wasm32-wasi --all-targets -- -D warnings
 
 # Use `--release` on CLI clippy to align with `test-cli`.
 # This reduces the size of the target directory which improves CI stability.
 fmt-cli:
-	cargo fmt --package=javy -- --check \
-		&& cargo clippy --package=javy --release --all-targets -- -D warnings
+	cargo fmt --package=javy -- --check
+	cargo clippy --package=javy --release --all-targets -- -D warnings
 
 clean: clean-wasi-sdk clean-cargo
 


### PR DESCRIPTION
I think the `&&`s were a holdover from when we were changing directories inside the recipes and they're not necessary now that we're no longer doing that.