### PR TITLE
Fix case where buffer capacity is exceeded

### DIFF
--- a/npm/javy/fs/index.ts
+++ b/npm/javy/fs/index.ts
@@ -32,9 +32,13 @@ export function writeFileSync(fd: number, buffer: Uint8Array) {
 	while (buffer.length > 0) {
 		// Try to write the entire buffer.
 		const bytesWritten = Javy.IO.writeSync(fd, buffer);
-		// A negative number of bytes read indicates an error.
+		// A negative number of bytes written indicates an error.
 		if (bytesWritten < 0) {
 			throw Error("Error while writing to file descriptor");
+		}
+		// 0 bytes means that the destination cannot accept additional bytes.
+		if (bytesWritten === 0) {
+			throw Error("Could not write all contents in buffer to file descriptor");
 		}
 		// Otherwise cut off the bytes from the buffer that
 		// were successfully written.

--- a/npm/javy/package-lock.json
+++ b/npm/javy/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "javy",
-	"version": "0.0.1",
+	"version": "0.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "javy",
-			"version": "0.0.1",
+			"version": "0.1.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@rollup/plugin-node-resolve": "^15.0.1",

--- a/npm/javy/package.json
+++ b/npm/javy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "javy",
-	"version": "0.0.1",
+	"version": "0.1.0",
 	"description": "",
 	"type": "module",
 	"author": "Surma <surma@shopify.com>",

--- a/npm/javy/tests/fixtures/exceeded_write_capacity.js
+++ b/npm/javy/tests/fixtures/exceeded_write_capacity.js
@@ -1,0 +1,15 @@
+import { writeFileSync } from "../../fs/index.ts";
+
+// use a stub version of writeSync that returns 0 bytes
+Javy.IO.writeSync = function () {
+    return 0;
+}
+
+try {
+    writeFileSync(1, new Uint8Array([42]));
+    throw Error("Expected writeFileSync to throw");
+} catch (e) {
+    if (e.message !== "Could not write all contents in buffer to file descriptor") {
+        throw Error(e);
+    }
+}

--- a/npm/javy/tests/tests.js
+++ b/npm/javy/tests/tests.js
@@ -34,6 +34,13 @@ export async function longDelay() {
 	});
 }
 
+export async function exceededWriteCapacity() {
+	await runJS({
+		source: "./fixtures/exceeded_write_capacity.js",
+		expectedOutput: "",
+	});
+}
+
 function sleep(ms) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
Addresses issue where `0` bytes written for a buffer containing a non-zero amount of bytes could infinitely loop. I've also opted to bump the package version to use a 0.1.x pattern so we can distinguish between changes that introduce breaking changes and changes that do not in the future.