### PR TITLE
chore: Update gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-crates/quickjs-wasm-sys/vendor/** linguist-generated
-crates/cli/vendor/** linguist-generated
+crates/quickjs-wasm-sys/quickjs/* linguist-vendored


### PR DESCRIPTION
To correctly reflect that quickjs is a vendored directory.

Ref: https://github.com/github/linguist/blob/master/docs/overrides.md#summary