### PR TITLE
Test for fuel consumption in integration tests

### DIFF
--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -7,48 +7,53 @@ use std::str;
 fn test_identity() {
     let mut runner = Runner::default();
 
-    let (output, _) = run_with_u8s(&mut runner, 42);
+    let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 42);
     assert_eq!(42, output);
+    assert_fuel_consumed_within_threshold(37907, fuel_consumed);
 }
 
 #[test]
 fn test_fib() {
     let mut runner = Runner::new("fib.js");
 
-    let (output, _) = run_with_u8s(&mut runner, 5);
+    let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 5);
     assert_eq!(8, output);
+    assert_fuel_consumed_within_threshold(59_822, fuel_consumed);
 }
 
 #[test]
 fn test_recursive_fib() {
     let mut runner = Runner::new("recursive-fib.js");
 
-    let (output, _) = run_with_u8s(&mut runner, 5);
+    let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 5);
     assert_eq!(8, output);
+    assert_fuel_consumed_within_threshold(61_617, fuel_consumed);
 }
 
 #[test]
 fn test_str() {
     let mut runner = Runner::new("str.js");
 
-    let (output, _) = run(&mut runner, "hello".as_bytes());
+    let (output, _, fuel_consumed) = run(&mut runner, "hello".as_bytes());
     assert_eq!("world".as_bytes(), output);
+    assert_fuel_consumed_within_threshold(142_849, fuel_consumed);
 }
 
 #[test]
 fn test_encoding() {
     let mut runner = Runner::new("text-encoding.js");
 
-    let (output, _) = run(&mut runner, "hello".as_bytes());
+    let (output, _, fuel_consumed) = run(&mut runner, "hello".as_bytes());
     assert_eq!("el".as_bytes(), output);
+    assert_fuel_consumed_within_threshold(258_852, fuel_consumed);
 
-    let (output, _) = run(&mut runner, "invalid".as_bytes());
+    let (output, _, _) = run(&mut runner, "invalid".as_bytes());
     assert_eq!("true".as_bytes(), output);
 
-    let (output, _) = run(&mut runner, "invalid_fatal".as_bytes());
+    let (output, _, _) = run(&mut runner, "invalid_fatal".as_bytes());
     assert_eq!("The encoded data was not valid utf-8".as_bytes(), output);
 
-    let (output, _) = run(&mut runner, "test".as_bytes());
+    let (output, _, _) = run(&mut runner, "test".as_bytes());
     assert_eq!("test2".as_bytes(), output);
 }
 
@@ -56,19 +61,21 @@ fn test_encoding() {
 fn test_logging() {
     let mut runner = Runner::new("logging.js");
 
-    let (_output, logs) = run(&mut runner, &[]);
+    let (_output, logs, fuel_consumed) = run(&mut runner, &[]);
     assert_eq!(
         "hello world from console.log\nhello world from console.error\n",
         logs.as_str(),
     );
+    assert_fuel_consumed_within_threshold(22_296, fuel_consumed);
 }
 
 #[test]
 fn test_readme_script() {
     let mut runner = Runner::new("readme.js");
 
-    let (output, _) = run(&mut runner, r#"{ "n": 2, "bar": "baz" }"#.as_bytes());
+    let (output, _, fuel_consumed) = run(&mut runner, r#"{ "n": 2, "bar": "baz" }"#.as_bytes());
     assert_eq!(r#"{"foo":3,"newBar":"baz!"}"#.as_bytes(), output);
+    assert_fuel_consumed_within_threshold(284_736, fuel_consumed);
 }
 
 #[cfg(feature = "experimental_event_loop")]
@@ -76,7 +83,7 @@ fn test_readme_script() {
 fn test_promises() {
     let mut runner = Runner::new("promise.js");
 
-    let (output, _) = run(&mut runner, &[]);
+    let (output, _, fuel_consumed) = run(&mut runner, &[]);
     assert_eq!("\"foo\"\"bar\"".as_bytes(), output);
 }
 
@@ -108,14 +115,35 @@ fn test_producers_section_present() {
     assert!(producers_string.contains("Javy"));
 }
 
-fn run_with_u8s(r: &mut Runner, stdin: u8) -> (u8, String) {
-    let (output, logs) = run(r, &stdin.to_le_bytes());
+fn run_with_u8s(r: &mut Runner, stdin: u8) -> (u8, String, u64) {
+    let (output, logs, fuel_consumed) = run(r, &stdin.to_le_bytes());
     assert_eq!(1, output.len());
-    (output[0], logs)
+    (output[0], logs, fuel_consumed)
 }
 
-fn run(r: &mut Runner, stdin: &[u8]) -> (Vec<u8>, String) {
-    let (output, logs) = r.exec(stdin).unwrap();
+fn run(r: &mut Runner, stdin: &[u8]) -> (Vec<u8>, String, u64) {
+    let (output, logs, fuel_consumed) = r.exec(stdin).unwrap();
     let logs = String::from_utf8(logs).unwrap();
-    (output, logs)
+    (output, logs, fuel_consumed)
+}
+
+/// Used to detect any significant changes in the fuel consumption when making changes in Javy.
+///
+/// A threshold is used here so that we can decide how much of a change is acceptable. The threshold value needs to be sufficiently large enough to account for fuel differences between different operating systems.
+///
+/// If the fuel_consumed is less than target_fuel, then great job decreasing the fuel consumption!
+/// However, if the fuel_consumed is greater than target_fuel and over the threshold, please consider if the changes are worth the increase in fuel consumption.
+fn assert_fuel_consumed_within_threshold(target_fuel: u64, fuel_consumed: u64) {
+    let target_fuel = target_fuel as f64;
+    let fuel_consumed = fuel_consumed as f64;
+    let threshold = 10.0;
+    let percentage_difference = ((fuel_consumed - target_fuel) / target_fuel).abs() * 100.0;
+
+    assert!(
+        percentage_difference <= threshold,
+        "fuel_consumed ({}) was not within {:.2}% of the target_fuel value ({})",
+        fuel_consumed,
+        threshold,
+        target_fuel
+    );
 }

--- a/crates/cli/tests/runner/mod.rs
+++ b/crates/cli/tests/runner/mod.rs
@@ -108,11 +108,12 @@ impl Runner {
         }
     }
 
-    pub fn exec(&mut self, input: &[u8]) -> Result<(Vec<u8>, Vec<u8>)> {
+    pub fn exec(&mut self, input: &[u8]) -> Result<(Vec<u8>, Vec<u8>, u64)> {
         let mut store = Store::new(
             self.linker.engine(),
             StoreContext::new(input, self.log_capacity),
         );
+        store.add_fuel(u64::MAX)?;
 
         let module = Module::from_binary(self.linker.engine(), &self.wasm)?;
 
@@ -120,6 +121,7 @@ impl Runner {
         let run = instance.get_typed_func::<(), (), _>(&mut store, "_start")?;
 
         let res = run.call(&mut store, ());
+        let fuel_consumed = store.fuel_consumed().unwrap();
         let store_context = store.into_data();
         drop(store_context.wasi);
         let logs = store_context
@@ -134,7 +136,7 @@ impl Runner {
             .into_inner();
 
         match res {
-            Ok(_) => Ok((output, logs)),
+            Ok(_) => Ok((output, logs, fuel_consumed)),
             Err(err) => Err(RunnerError {
                 stdout: output,
                 stderr: logs,
@@ -148,6 +150,7 @@ impl Runner {
 fn setup_engine() -> Engine {
     let mut config = Config::new();
     config.cranelift_opt_level(OptLevel::SpeedAndSize);
+    config.consume_fuel(true);
     Engine::new(&config).expect("failed to create engine")
 }
 


### PR DESCRIPTION
Given Shopify's relatively strict requirements around fuel usage, I think it's important that any changes we make do not increase fuel consumption significantly as changes here are out of the control of a Shopify partner so we need to be extra careful.

This PR adds some baseline values to assert that fuel consumed in our integration tests do not exceed a certain threshold. I'm currently defining that threshold as 10% but open to discussing other values. This threshold value needs to be large enough to account for fuel differences between different operating systems so the test does not end up being inconsistent


Example of a failed test
```
thread 'test_identity' panicked at 'fuel_consumed (37907) was not within 1.00% of the target_fuel value (39907)', crates/cli/tests/integration_test.rs:142:5
```

