### PR TITLE
Add glibc runtime requirement to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 **Introduction**: Run your JavaScript on WebAssembly. Javy takes your JavaScript code, and executes it in a WebAssembly embedded JavaScript runtime. Javy can create _very_ small Wasm modules in the 1 to 16 KB range with use of dynamic linking. The default static linking produces modules that are at least 869 KB in size.
 
+## Runtime requirements
+
+When running the official Javy binary on Linux, `glibc` 2.31 or greater must be available. You may need to update the version of your operating system if you are using an older version of `glibc`.
+
 ## Contributing
 
 We welcome feedback, bug reports and bug fixes. We're also happy to discuss feature development but please discuss the features in an issue before contributing.


### PR DESCRIPTION
Add a point to the README for cases like https://github.com/Shopify/javy/issues/307 since the cause of the error may not be obvious.