### PR TITLE
Introduce CallbackArg 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "javy-core"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "javy",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-rs"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "javy-core"
-version = "0.3.0-alpha.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "javy",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-core"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-core"
-version = "0.3.0-alpha.1"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use javy::quickjs::{JSContextRef, JSError, JSValue, CallbackArg};
+use javy::quickjs::{CallbackArg, JSContextRef, JSError, JSValue};
 use std::borrow::Cow;
 use std::io::{Read, Write};
 use std::str;

--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -192,10 +192,10 @@ mod tests {
 
         ctx.eval_global(
             "main",
-            "console.log(2.3, true, { foo: 'bar' }, null, undefined, [1, 2, 3])",
+            "console.log(2.3, true, { foo: 'bar' }, null, undefined)",
         )?;
         assert_eq!(
-            b"2.3 true [object Object] null undefined 1,2,3\n",
+            b"2.3 true [object Object] null undefined\n",
             stream.buffer.borrow().as_slice()
         );
         Ok(())
@@ -242,32 +242,6 @@ mod tests {
 
         Ok(())
     }
-
-    // sanity test for when I was prototyping - send 'hello' into stdin to pass test
-    // #[test]
-    // fn test_read_sync() -> Result<()> {
-    //     let stream = SharedStream::default();
-
-    //     let ctx = JSContextRef::default();
-    //     inject_javy_globals(&ctx, stream.clone(), stream.clone())?;
-
-    //     ctx.eval_global("main", "const buffer = new Uint8Array(5); Javy.IO.readSync(0, buffer); console.log(new TextDecoder().decode(buffer))")?;
-    //     assert_eq!(b"hello\n", stream.buffer.borrow().as_slice());
-    //     Ok(())
-    // }
-
-    // // sanity test for when I was prototyping - visually inspect that the string 'helloJACKSON' is printed to stdout
-    // #[test]
-    // fn test_write_sync() -> Result<()> {
-    //     let stream = SharedStream::default();
-
-    //     let ctx = JSContextRef::default();
-    //     inject_javy_globals(&ctx, stream.clone(), stream.clone())?;
-
-    //     ctx.eval_global("main", "let encoder = new TextEncoder(); let buffer = encoder.encode('helloJACKSON'); Javy.IO.writeSync(1, buffer);")?;
-
-    //     Ok(())
-    // }
 
     #[derive(Clone)]
     struct SharedStream {

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-rs"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/quickjs-wasm-rs/src/js_binding/context.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/context.rs
@@ -288,7 +288,7 @@ impl JSContextRef {
 
     /// Wrap the specified function in a JS function.
     ///
-    /// Since the callback signature accepts parameters as high-level `Context` and `Value` objects, it can be
+    /// Since the callback signature accepts parameters as high-level `JSContextRef` and `CallbackArg` objects, it can be
     /// implemented without using `unsafe` code, unlike [JSContextRef::new_callback] which provides a low-level API.
     /// Returning a [JSError] from the callback will cause a JavaScript error with the appropriate
     /// type to be thrown.

--- a/crates/quickjs-wasm-rs/src/js_binding/context.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/context.rs
@@ -2,6 +2,7 @@ use super::constants::{MAX_SAFE_INTEGER, MIN_SAFE_INTEGER};
 use super::error::JSError;
 use super::exception::Exception;
 use super::value::JSValueRef;
+use crate::js_value::{self, qjs_convert, CallbackArg};
 use anyhow::Result;
 use once_cell::sync::Lazy;
 use quickjs_wasm_sys::{
@@ -293,51 +294,60 @@ impl JSContextRef {
     /// type to be thrown.
     pub fn wrap_callback<F>(&self, mut f: F) -> Result<JSValueRef>
     where
-        F: (FnMut(&Self, &JSValueRef, &[JSValueRef]) -> Result<JSValueRef>) + 'static,
+        F: (FnMut(&Self, &CallbackArg, &[CallbackArg]) -> Result<js_value::JSValue>) + 'static,
     {
-        let wrapped = move |inner, this, argc, argv: *mut JSValue, _| match f(
-            &Self { inner },
-            &JSValueRef::new_unchecked(inner, this),
-            &(0..argc)
-                .map(|offset| {
-                    JSValueRef::new_unchecked(inner, unsafe { *argv.offset(offset as isize) })
-                })
-                .collect::<Box<[_]>>(),
-        ) {
-            Ok(value) => value.value,
-            Err(error) => {
-                let format = CString::new("%s").unwrap();
-                match error.downcast::<JSError>() {
-                    Ok(js_error) => {
-                        let message = CString::new(js_error.to_string())
-                            .unwrap_or_else(|_| CString::new("Unknown error").unwrap());
-                        match js_error {
-                            JSError::Internal(_) => unsafe {
-                                JS_ThrowInternalError(inner, format.as_ptr(), message.as_ptr())
-                            },
-                            JSError::Syntax(_) => unsafe {
-                                JS_ThrowSyntaxError(inner, format.as_ptr(), message.as_ptr())
-                            },
-                            JSError::Type(_) => unsafe {
-                                JS_ThrowTypeError(inner, format.as_ptr(), message.as_ptr())
-                            },
-                            JSError::Reference(_) => unsafe {
-                                JS_ThrowReferenceError(inner, format.as_ptr(), message.as_ptr())
-                            },
-                            JSError::Range(_) => unsafe {
-                                JS_ThrowRangeError(inner, format.as_ptr(), message.as_ptr())
-                            },
+        let wrapped = move |inner, this, argc, argv: *mut JSValue, _| {
+            let inner_ctx = JSContextRef { inner };
+            match f(
+                &inner_ctx,
+                &CallbackArg::new(JSValueRef::new_unchecked(inner, this)),
+                &(0..argc)
+                    .map(|offset| {
+                        CallbackArg::new(JSValueRef::new_unchecked(inner, unsafe {
+                            *argv.offset(offset as isize)
+                        }))
+                    })
+                    .collect::<Box<[_]>>(),
+            ) {
+                Ok(value) => qjs_convert::to_qjs_value(&inner_ctx, &value).unwrap().value,
+                Err(error) => {
+                    let format = CString::new("%s").unwrap();
+                    match error.downcast::<JSError>() {
+                        Ok(js_error) => {
+                            let message = CString::new(js_error.to_string())
+                                .unwrap_or_else(|_| CString::new("Unknown error").unwrap());
+                            match js_error {
+                                JSError::Internal(_) => unsafe {
+                                    JS_ThrowInternalError(inner, format.as_ptr(), message.as_ptr())
+                                },
+                                JSError::Syntax(_) => unsafe {
+                                    JS_ThrowSyntaxError(inner, format.as_ptr(), message.as_ptr())
+                                },
+                                JSError::Type(_) => unsafe {
+                                    JS_ThrowTypeError(inner, format.as_ptr(), message.as_ptr())
+                                },
+                                JSError::Reference(_) => unsafe {
+                                    JS_ThrowReferenceError(inner, format.as_ptr(), message.as_ptr())
+                                },
+                                JSError::Range(_) => unsafe {
+                                    JS_ThrowRangeError(inner, format.as_ptr(), message.as_ptr())
+                                },
+                            }
                         }
-                    }
-                    Err(e) => {
-                        let message = format!("{e:?}");
-                        let message = CString::new(message.as_str()).unwrap_or_else(|err| {
-                            CString::new(format!("{} - truncated due to null byte", unsafe {
-                                str::from_utf8_unchecked(&message.as_bytes()[..err.nul_position()])
-                            }))
-                            .unwrap()
-                        });
-                        unsafe { JS_ThrowInternalError(inner, format.as_ptr(), message.as_ptr()) }
+                        Err(e) => {
+                            let message = format!("{e:?}");
+                            let message = CString::new(message.as_str()).unwrap_or_else(|err| {
+                                CString::new(format!("{} - truncated due to null byte", unsafe {
+                                    str::from_utf8_unchecked(
+                                        &message.as_bytes()[..err.nul_position()],
+                                    )
+                                }))
+                                .unwrap()
+                            });
+                            unsafe {
+                                JS_ThrowInternalError(inner, format.as_ptr(), message.as_ptr())
+                            }
+                        }
                     }
                 }
             }

--- a/crates/quickjs-wasm-rs/src/js_binding/value.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/value.rs
@@ -22,7 +22,7 @@ pub enum BigInt {
     Unsigned(u64),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct JSValueRef {
     pub(super) context: *mut JSContext,
     pub(super) value: JSValue,

--- a/crates/quickjs-wasm-rs/src/js_value/callback_arg.rs
+++ b/crates/quickjs-wasm-rs/src/js_value/callback_arg.rs
@@ -1,0 +1,206 @@
+use std::{collections::HashMap, convert::TryInto, fmt};
+
+use anyhow::Result;
+
+use super::{qjs_convert::from_qjs_value, JSValue};
+use crate::js_binding::value::JSValueRef;
+
+#[derive(Copy, Clone)]
+pub struct CallbackArg {
+    inner: JSValueRef,
+}
+
+impl CallbackArg {
+    pub fn new(inner: JSValueRef) -> Self {
+        Self { inner }
+    }
+
+    pub unsafe fn inner_value(&self) -> JSValueRef {
+        self.inner
+    }
+
+    fn to_js_value(&self) -> Result<JSValue> {
+        from_qjs_value(&self.inner)
+    }
+}
+
+impl fmt::Display for CallbackArg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_js_value().unwrap())
+    }
+}
+
+macro_rules! try_from_impl {
+    ($($t:ty),+ $(,)?) => {
+        $(impl TryFrom<&CallbackArg> for $t {
+            type Error = anyhow::Error;
+
+            fn try_from(value: &CallbackArg) -> Result<Self> {
+                value.to_js_value()?.try_into()
+            }
+        }
+
+        impl TryFrom<CallbackArg> for $t {
+            type Error = anyhow::Error;
+
+            fn try_from(value: CallbackArg) -> Result<Self> {
+                value.to_js_value()?.try_into()
+            }
+        })+
+    };
+}
+
+try_from_impl!(
+    bool,
+    i32,
+    usize,
+    f64,
+    String,
+    Vec<JSValue>,
+    Vec<u8>,
+    HashMap<String, JSValue>,
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::js_binding::context::JSContextRef;
+
+    #[test]
+    fn test_bool() -> Result<()> {
+        let context = JSContextRef::default();
+        let val = context.eval_global("test.js", "true").unwrap();
+
+        let callback_arg = CallbackArg::new(val);
+        assert_eq!("true", callback_arg.to_string());
+        let arg: bool = callback_arg.try_into()?;
+        assert_eq!(true, arg);
+
+        let callback_arg_ref = &callback_arg;
+        let arg: bool = callback_arg_ref.try_into()?;
+        assert_eq!(true, arg);
+        Ok(())
+    }
+
+    #[test]
+    fn test_i32() -> Result<()> {
+        let context = JSContextRef::default();
+        let val = context.eval_global("test.js", "42").unwrap();
+
+        let callback_arg = CallbackArg::new(val);
+        assert_eq!("42", callback_arg.to_string());
+        let arg: i32 = callback_arg.try_into()?;
+        assert_eq!(42, arg);
+
+        let callback_arg_ref = &callback_arg;
+        let arg: i32 = callback_arg_ref.try_into()?;
+        assert_eq!(42, arg);
+        Ok(())
+    }
+
+    #[test]
+    fn test_usize() -> Result<()> {
+        let context = JSContextRef::default();
+        let val = context.eval_global("test.js", "42").unwrap();
+
+        let callback_arg = CallbackArg::new(val);
+        assert_eq!("42", callback_arg.to_string());
+        let arg: usize = callback_arg.try_into()?;
+        assert_eq!(42, arg);
+
+        let callback_arg_ref = &callback_arg;
+        let arg: usize = callback_arg_ref.try_into()?;
+        assert_eq!(42, arg);
+        Ok(())
+    }
+
+    #[test]
+    fn test_f64() -> Result<()> {
+        let context = JSContextRef::default();
+        let val = context.eval_global("test.js", "42.42").unwrap();
+
+        let callback_arg = CallbackArg::new(val);
+        assert_eq!("42.42", callback_arg.to_string());
+        let arg: f64 = callback_arg.try_into()?;
+        assert_eq!(42.42, arg);
+
+        let callback_arg_ref = &callback_arg;
+        let arg: f64 = callback_arg_ref.try_into()?;
+        assert_eq!(42.42, arg);
+        Ok(())
+    }
+
+    #[test]
+    fn test_string() -> Result<()> {
+        let context = JSContextRef::default();
+        let val = context.eval_global("test.js", "const h = 'hello'; h").unwrap();
+
+        let callback_arg = CallbackArg::new(val);
+        assert_eq!("hello", callback_arg.to_string());
+        let arg: String = callback_arg.try_into()?;
+        assert_eq!("hello", arg);
+
+        let callback_arg_ref = &callback_arg;
+        let arg: String = callback_arg_ref.try_into()?;
+        assert_eq!("hello", arg);
+        Ok(())
+    }
+
+    #[test]
+    fn test_vec() -> Result<()> {
+        let context = JSContextRef::default();
+        let val = context.eval_global("test.js", "[1, 2, 3]").unwrap();
+
+        let expected: Vec<JSValue> = vec![1.into(), 2.into(), 3.into()];
+        
+        let callback_arg = CallbackArg::new(val);
+        assert_eq!("1,2,3", callback_arg.to_string());
+        let arg: Vec<JSValue> = callback_arg.try_into()?;
+        assert_eq!(expected, arg);
+
+        let callback_arg_ref = &callback_arg;
+        let arg: Vec<JSValue> = callback_arg_ref.try_into()?;
+        assert_eq!(expected, arg);
+        Ok(())
+    }
+
+    #[test]
+    fn test_bytes() -> Result<()> {
+        let context = JSContextRef::default();
+        let val = context.eval_global("test.js", "new ArrayBuffer(8)").unwrap();
+
+        let expected = [0_u8; 8].to_vec();
+        
+        let callback_arg = CallbackArg::new(val);
+        assert_eq!("[object ArrayBuffer]", callback_arg.to_string());
+        let arg: Vec<u8> = callback_arg.try_into()?;
+        assert_eq!(expected, arg);
+
+        let callback_arg_ref = &callback_arg;
+        let arg: Vec<u8> = callback_arg_ref.try_into()?;
+        assert_eq!(expected, arg);
+        Ok(())
+    }
+
+    #[test]
+    fn test_hashmap() -> Result<()> {
+        let context = JSContextRef::default();
+        let val = context.eval_global("test.js", "({a: 1, b: 2, c: 3})").unwrap();
+
+        let expected = HashMap::from([
+            ("a".to_string(), 1.into()),
+            ("b".to_string(), 2.into()),
+            ("c".to_string(), 3.into()),
+        ]);
+        
+        let callback_arg = CallbackArg::new(val);
+        assert_eq!("[object Object]", callback_arg.to_string());
+        let arg: HashMap<String, JSValue> = callback_arg.try_into()?;
+        assert_eq!(expected, arg);
+
+        let callback_arg_ref = &callback_arg;
+        let arg: HashMap<String, JSValue> = callback_arg_ref.try_into()?;
+        assert_eq!(expected, arg);
+        Ok(())
+    }
+}

--- a/crates/quickjs-wasm-rs/src/js_value/callback_arg.rs
+++ b/crates/quickjs-wasm-rs/src/js_value/callback_arg.rs
@@ -90,7 +90,7 @@ mod tests {
     #[test]
     fn test_bool() -> Result<()> {
         let context = JSContextRef::default();
-        let val = context.eval_global("test.js", "true").unwrap();
+        let val = context.eval_global("test.js", "true")?;
 
         let callback_arg = CallbackArg::new(val);
         assert_eq!("true", callback_arg.to_string());
@@ -106,7 +106,7 @@ mod tests {
     #[test]
     fn test_i32() -> Result<()> {
         let context = JSContextRef::default();
-        let val = context.eval_global("test.js", "42").unwrap();
+        let val = context.eval_global("test.js", "42")?;
 
         let callback_arg = CallbackArg::new(val);
         assert_eq!("42", callback_arg.to_string());
@@ -122,7 +122,7 @@ mod tests {
     #[test]
     fn test_usize() -> Result<()> {
         let context = JSContextRef::default();
-        let val = context.eval_global("test.js", "42").unwrap();
+        let val = context.eval_global("test.js", "42")?;
 
         let callback_arg = CallbackArg::new(val);
         assert_eq!("42", callback_arg.to_string());
@@ -138,7 +138,7 @@ mod tests {
     #[test]
     fn test_f64() -> Result<()> {
         let context = JSContextRef::default();
-        let val = context.eval_global("test.js", "42.42").unwrap();
+        let val = context.eval_global("test.js", "42.42")?;
 
         let callback_arg = CallbackArg::new(val);
         assert_eq!("42.42", callback_arg.to_string());
@@ -154,9 +154,7 @@ mod tests {
     #[test]
     fn test_string() -> Result<()> {
         let context = JSContextRef::default();
-        let val = context
-            .eval_global("test.js", "const h = 'hello'; h")
-            .unwrap();
+        let val = context.eval_global("test.js", "const h = 'hello'; h")?;
 
         let callback_arg = CallbackArg::new(val);
         assert_eq!("hello", callback_arg.to_string());
@@ -172,7 +170,7 @@ mod tests {
     #[test]
     fn test_vec() -> Result<()> {
         let context = JSContextRef::default();
-        let val = context.eval_global("test.js", "[1, 2, 3]").unwrap();
+        let val = context.eval_global("test.js", "[1, 2, 3]")?;
 
         let expected: Vec<JSValue> = vec![1.into(), 2.into(), 3.into()];
 
@@ -190,9 +188,7 @@ mod tests {
     #[test]
     fn test_bytes() -> Result<()> {
         let context = JSContextRef::default();
-        let val = context
-            .eval_global("test.js", "new ArrayBuffer(8)")
-            .unwrap();
+        let val = context.eval_global("test.js", "new ArrayBuffer(8)")?;
 
         let expected = [0_u8; 8].to_vec();
 
@@ -210,9 +206,7 @@ mod tests {
     #[test]
     fn test_hashmap() -> Result<()> {
         let context = JSContextRef::default();
-        let val = context
-            .eval_global("test.js", "({a: 1, b: 2, c: 3})")
-            .unwrap();
+        let val = context.eval_global("test.js", "({a: 1, b: 2, c: 3})")?;
 
         let expected = HashMap::from([
             ("a".to_string(), 1.into()),

--- a/crates/quickjs-wasm-rs/src/js_value/mod.rs
+++ b/crates/quickjs-wasm-rs/src/js_value/mod.rs
@@ -1,8 +1,12 @@
 use std::{collections::HashMap, fmt};
 
 pub mod qjs_convert;
+
+mod callback_arg;
 mod to_js_value;
 mod try_from_js_value;
+
+pub use callback_arg::CallbackArg;
 
 /// A safe and high level representation of a JavaScript value.
 ///

--- a/crates/quickjs-wasm-rs/src/lib.rs
+++ b/crates/quickjs-wasm-rs/src/lib.rs
@@ -7,7 +7,7 @@ pub use crate::js_binding::error::JSError;
 pub use crate::js_binding::exception::Exception;
 pub use crate::js_binding::value::JSValueRef;
 pub use crate::js_value::qjs_convert::*;
-pub use crate::js_value::JSValue;
+pub use crate::js_value::{CallbackArg, JSValue};
 pub use crate::serialize::de::Deserializer;
 pub use crate::serialize::ser::Serializer;
 

--- a/crates/quickjs-wasm-rs/src/serialize/de.rs
+++ b/crates/quickjs-wasm-rs/src/serialize/de.rs
@@ -98,7 +98,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer {
         if self.value.is_array() {
             let val = self.value.get_property("length")?;
             let length = val.as_u32_unchecked();
-            let seq = self.value.clone();
+            let seq = self.value;
             let seq_access = SeqAccess {
                 de: self,
                 length,

--- a/crates/quickjs-wasm-rs/src/serialize/ser.rs
+++ b/crates/quickjs-wasm-rs/src/serialize/ser.rs
@@ -196,7 +196,7 @@ impl<'a> ser::Serializer for &'a mut Serializer<'_> {
     {
         let object = self.context.object_value()?;
         value.serialize(&mut *self)?;
-        object.set_property(variant, self.value.clone())?;
+        object.set_property(variant, self.value)?;
         self.value = object;
 
         Ok(())


### PR DESCRIPTION
Part of https://github.com/Shopify/javy/issues/295

This PR introduces the `CallbackArg` which wraps a ` JSValueRef` and is used to lazily convert the underlying `JSValueRef` to a `JSValue` type for callback functions to use. 

I also created a macro for `impl TryFrom<CallbackArg>` AND `impl TryFrom<&CallbackArg>` because in `wrap_callback` we provide callback functions with both `CallbackArg` and `&CallbackArg` types so having `TryFrom` implementations for both of these is really convenient. 

`wrap_callback` now takes a `impl FnMut(&JSContextRef, &CallbackArg, &[CallbackArg]) -> anyhow::Result<JSValue>` callback function. This means users no longer directly have to interface with `JSValueRef` and get to work with native Rust types and `JSValue`.

