### PR TITLE
Rename CLI crate to javy-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "javy"
+name = "javy-cli"
 version = "0.6.0"
 dependencies = [
  "anyhow",

--- a/Makefile
+++ b/Makefile
@@ -8,20 +8,20 @@ install:
 	cargo install --path crates/cli
 
 bench: cli
-	cargo bench --package=javy
+	cargo bench --package=javy-cli
 
 check-bench:
-	cargo check --package=javy --release --benches
+	cargo check --package=javy-cli --release --benches
 
 cli: core
-	cargo build --package=javy --release
+	cargo build --package=javy-cli --release
 
 core:
 	cargo build --package=javy-core --release --target=wasm32-wasi --features=$(CORE_FEATURES)
 	wizer target/wasm32-wasi/release/javy_quickjs_provider.wasm --allow-wasi --wasm-bulk-memory true -o target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm
 
 docs:
-	cargo doc --package=javy --open
+	cargo doc --package=javy-cli --open
 	cargo doc --package=javy-core --open --target=wasm32-wasi
 
 test-quickjs-wasm-rs:
@@ -33,7 +33,7 @@ test-core:
 # Test in release mode to skip some debug assertions
 # Note: to make this faster, the engine should be optimized beforehand (wasm-strip + wasm-opt).
 test-cli: core
-	cargo test --package=javy --release --features=$(CLI_FEATURES) -- --nocapture
+	cargo test --package=javy-cli --release --features=$(CLI_FEATURES) -- --nocapture
 
 # WPT requires a Javy build with the experimental_event_loop feature to pass
 test-wpt: export CORE_FEATURES ?= experimental_event_loop
@@ -62,8 +62,8 @@ fmt-core:
 # Use `--release` on CLI clippy to align with `test-cli`.
 # This reduces the size of the target directory which improves CI stability.
 fmt-cli:
-	cargo fmt --package=javy -- --check
-	cargo clippy --package=javy --release --all-targets -- -D warnings
+	cargo fmt --package=javy-cli -- --check
+	cargo clippy --package=javy-cli --release --all-targets -- -D warnings
 
 clean: clean-wasi-sdk clean-cargo
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "javy"
+name = "javy-cli"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
@@ -8,6 +8,7 @@ build = "build.rs"
 
 [[bin]]
 name = "javy"
+path = "src/main.rs"
 
 [features]
 dump_wat = ["dep:wasmprinter"]


### PR DESCRIPTION
Part of #310. We need to rename the CLI crate to be able to introduce a new library crate named Javy. This change preserves the binary's name as `javy`.