### PR TITLE
Add javy crate scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,6 +1051,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "javy"
+version = "1.0.0-alpha1"
+dependencies = [
+ "anyhow",
+ "quickjs-wasm-rs",
+]
+
+[[package]]
 name = "javy-cli"
 version = "0.6.0"
 dependencies = [
@@ -1080,8 +1088,8 @@ name = "javy-core"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "javy",
  "once_cell",
- "quickjs-wasm-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "crates/quickjs-wasm-sys",
   "crates/quickjs-wasm-rs",
+  "crates/javy",
   "crates/core",
   "crates/cli",
 ]

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ docs:
 test-quickjs-wasm-rs:
 	cargo wasi test --package=quickjs-wasm-rs --features json,messagepack -- --nocapture
 
+test-javy:
+	cargo wasi test --package=javy -- --nocapture
+
 test-core:
 	cargo wasi test --package=javy-core -- --nocapture
 
@@ -43,9 +46,9 @@ test-wpt:
 	npm install --prefix wpt
 	npm test --prefix wpt 
 
-tests: test-quickjs-wasm-rs test-core test-cli test-wpt
+tests: test-quickjs-wasm-rs test-javy test-core test-cli test-wpt
 
-fmt: fmt-quickjs-wasm-sys fmt-quickjs-wasm-rs fmt-core fmt-cli
+fmt: fmt-quickjs-wasm-sys fmt-quickjs-wasm-rs fmt-javy fmt-core fmt-cli
 
 fmt-quickjs-wasm-sys:
 	cargo fmt --package=quickjs-wasm-sys -- --check
@@ -54,6 +57,10 @@ fmt-quickjs-wasm-sys:
 fmt-quickjs-wasm-rs:
 	cargo fmt --package=quickjs-wasm-rs -- --check
 	cargo clippy --package=quickjs-wasm-rs --target=wasm32-wasi --all-targets -- -D warnings
+
+fmt-javy:
+	cargo fmt --package=javy -- --check
+	cargo clippy --package=javy --target=wasm32-wasi --all-targets -- -D warnings
 
 fmt-core:
 	cargo fmt --package=javy-core -- --check

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-rs = { path = "../quickjs-wasm-rs" }
+javy = { path = "../javy" }
 once_cell = { workspace = true }
 
 [features]

--- a/crates/core/src/execution.rs
+++ b/crates/core/src/execution.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use quickjs_wasm_rs::JSContextRef;
+use javy::quickjs::JSContextRef;
 
 pub fn run_bytecode(context: &JSContextRef, bytecode: &[u8]) -> Result<()> {
     context.eval_binary(bytecode)?;

--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use quickjs_wasm_rs::{JSContextRef, JSError, JSValueRef};
+use javy::quickjs::{JSContextRef, JSError, JSValueRef};
 use std::borrow::Cow;
 use std::io::{Read, Write};
 use std::str;
@@ -198,7 +198,7 @@ fn js_args_to_io_reader(args: &[JSValueRef]) -> anyhow::Result<(Box<dyn Read>, &
 mod tests {
     use super::inject_javy_globals;
     use anyhow::Result;
-    use quickjs_wasm_rs::JSContextRef;
+    use javy::quickjs::JSContextRef;
     use std::cell::RefCell;
     use std::rc::Rc;
     use std::{cmp, io};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,5 @@
+use javy::quickjs::JSContextRef;
 use once_cell::sync::OnceCell;
-use quickjs_wasm_rs::JSContextRef;
 use std::alloc::{alloc, dealloc, Layout};
 use std::io;
 use std::ptr::copy_nonoverlapping;

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -1,5 +1,5 @@
+use javy::quickjs::JSContextRef;
 use once_cell::sync::OnceCell;
-use quickjs_wasm_rs::JSContextRef;
 use std::io::{self, Read};
 use std::string::String;
 

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "javy"
+version = "1.0.0-alpha1"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+quickjs-wasm-rs = { path = "../quickjs-wasm-rs" }

--- a/crates/javy/src/lib.rs
+++ b/crates/javy/src/lib.rs
@@ -1,0 +1,1 @@
+pub use quickjs_wasm_rs as quickjs;


### PR DESCRIPTION
Part of #310. Adds a `javy` crate that just re-exports `quickjs-wasm-rs` under `javy`. More will be added to the crate in a future PR. I didn't want to mix the scaffolding with the interesting changes in a single PR.