### PR TITLE
Add Runtime and Config

### DIFF
--- a/crates/core/src/execution.rs
+++ b/crates/core/src/execution.rs
@@ -1,7 +1,8 @@
 use anyhow::{bail, Result};
-use javy::quickjs::JSContextRef;
+use javy::Runtime;
 
-pub fn run_bytecode(context: &JSContextRef, bytecode: &[u8]) -> Result<()> {
+pub fn run_bytecode(runtime: &Runtime, bytecode: &[u8]) -> Result<()> {
+    let context = runtime.context();
     context.eval_binary(bytecode)?;
     if cfg!(feature = "experimental_event_loop") {
         context.execute_pending()?;

--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -1,11 +1,12 @@
 use anyhow::anyhow;
 use javy::quickjs::{CallbackArg, JSContextRef, JSError, JSValue};
+use javy::Runtime;
 use std::borrow::Cow;
 use std::io::{Read, Write};
 use std::str;
 
 pub fn inject_javy_globals<T1, T2>(
-    context: &JSContextRef,
+    runtime: &Runtime,
     log_stream: T1,
     error_stream: T2,
 ) -> anyhow::Result<()>
@@ -13,6 +14,7 @@ where
     T1: Write + 'static,
     T2: Write + 'static,
 {
+    let context = runtime.context();
     let global = context.global_object()?;
 
     let console_log_callback = context.wrap_callback(console_log_to(log_stream))?;
@@ -166,9 +168,10 @@ fn encode_js_string_to_utf8_buffer(
 
 #[cfg(test)]
 mod tests {
+    use crate::runtime;
+
     use super::inject_javy_globals;
     use anyhow::Result;
-    use javy::quickjs::JSContextRef;
     use std::cell::RefCell;
     use std::rc::Rc;
     use std::{cmp, io};
@@ -177,8 +180,9 @@ mod tests {
     fn test_console_log() -> Result<()> {
         let mut stream = SharedStream::default();
 
-        let ctx = JSContextRef::default();
-        inject_javy_globals(&ctx, stream.clone(), stream.clone())?;
+        let runtime = runtime::new_runtime()?;
+        let ctx = runtime.context();
+        inject_javy_globals(&runtime, stream.clone(), stream.clone())?;
 
         ctx.eval_global("main", "console.log(\"hello world\");")?;
         assert_eq!(b"hello world\n", stream.buffer.borrow().as_slice());
@@ -205,8 +209,9 @@ mod tests {
     fn test_console_error() -> Result<()> {
         let mut stream = SharedStream::default();
 
-        let ctx = JSContextRef::default();
-        inject_javy_globals(&ctx, stream.clone(), stream.clone())?;
+        let runtime = runtime::new_runtime()?;
+        let ctx = runtime.context();
+        inject_javy_globals(&runtime, stream.clone(), stream.clone())?;
 
         ctx.eval_global("main", "console.error(\"hello world\");")?;
         assert_eq!(b"hello world\n", stream.buffer.borrow().as_slice());
@@ -232,8 +237,9 @@ mod tests {
     #[test]
     fn test_text_encoder_decoder() -> Result<()> {
         let stream = SharedStream::default();
-        let ctx = JSContextRef::default();
-        inject_javy_globals(&ctx, stream.clone(), stream.clone())?;
+        let runtime = runtime::new_runtime()?;
+        let ctx = runtime.context();
+        inject_javy_globals(&runtime, stream.clone(), stream.clone())?;
         ctx.eval_global(
             "main",
             "let encoder = new TextEncoder(); let buffer = encoder.encode('hello'); let decoder = new TextDecoder(); console.log(decoder.decode(buffer));"

--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -180,7 +180,7 @@ mod tests {
     fn test_console_log() -> Result<()> {
         let mut stream = SharedStream::default();
 
-        let runtime = runtime::new_runtime()?;
+        let runtime = runtime::new_runtime();
         let ctx = runtime.context();
         inject_javy_globals(&runtime, stream.clone(), stream.clone())?;
 
@@ -209,7 +209,7 @@ mod tests {
     fn test_console_error() -> Result<()> {
         let mut stream = SharedStream::default();
 
-        let runtime = runtime::new_runtime()?;
+        let runtime = runtime::new_runtime();
         let ctx = runtime.context();
         inject_javy_globals(&runtime, stream.clone(), stream.clone())?;
 
@@ -237,7 +237,7 @@ mod tests {
     #[test]
     fn test_text_encoder_decoder() -> Result<()> {
         let stream = SharedStream::default();
-        let runtime = runtime::new_runtime()?;
+        let runtime = runtime::new_runtime();
         let ctx = runtime.context();
         inject_javy_globals(&runtime, stream.clone(), stream.clone())?;
         ctx.eval_global(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -23,7 +23,7 @@ static mut RUNTIME: OnceCell<Runtime> = OnceCell::new();
 /// Used by Wizer to preinitialize the module
 #[export_name = "wizer.initialize"]
 pub extern "C" fn init() {
-    let runtime = runtime::new_runtime().unwrap();
+    let runtime = runtime::new_runtime();
     globals::inject_javy_globals(&runtime, io::stderr(), io::stderr()).unwrap();
     unsafe { RUNTIME.set(runtime).unwrap() };
 }
@@ -44,7 +44,7 @@ pub extern "C" fn init() {
 #[export_name = "compile_src"]
 pub unsafe extern "C" fn compile_src(js_src_ptr: *const u8, js_src_len: usize) -> *const u32 {
     // Use fresh runtime to avoid depending on Wizened runtime
-    let runtime = runtime::new_runtime().unwrap();
+    let runtime = runtime::new_runtime();
     let js_src = str::from_utf8(slice::from_raw_parts(js_src_ptr, js_src_len)).unwrap();
     let bytecode = runtime
         .context()

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -12,7 +12,7 @@ static mut BYTECODE: OnceCell<Vec<u8>> = OnceCell::new();
 
 #[export_name = "wizer.initialize"]
 pub extern "C" fn init() {
-    let runtime = runtime::new_runtime().unwrap();
+    let runtime = runtime::new_runtime();
     globals::inject_javy_globals(&runtime, io::stderr(), io::stderr()).unwrap();
 
     let mut contents = String::new();

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -1,31 +1,35 @@
-use javy::quickjs::JSContextRef;
+use javy::Runtime;
 use once_cell::sync::OnceCell;
 use std::io::{self, Read};
 use std::string::String;
 
 mod execution;
 mod globals;
+mod runtime;
 
-static mut CONTEXT: OnceCell<JSContextRef> = OnceCell::new();
+static mut RUNTIME: OnceCell<Runtime> = OnceCell::new();
 static mut BYTECODE: OnceCell<Vec<u8>> = OnceCell::new();
 
 #[export_name = "wizer.initialize"]
 pub extern "C" fn init() {
-    let context = JSContextRef::default();
-    globals::inject_javy_globals(&context, io::stderr(), io::stderr()).unwrap();
+    let runtime = runtime::new_runtime().unwrap();
+    globals::inject_javy_globals(&runtime, io::stderr(), io::stderr()).unwrap();
 
     let mut contents = String::new();
     io::stdin().read_to_string(&mut contents).unwrap();
-    let bytecode = context.compile_module("function.mjs", &contents).unwrap();
+    let bytecode = runtime
+        .context()
+        .compile_module("function.mjs", &contents)
+        .unwrap();
 
     unsafe {
-        CONTEXT.set(context).unwrap();
+        RUNTIME.set(runtime).unwrap();
         BYTECODE.set(bytecode).unwrap();
     }
 }
 
 fn main() {
     let bytecode = unsafe { BYTECODE.take().unwrap() };
-    let context = unsafe { CONTEXT.take().unwrap() };
-    execution::run_bytecode(&context, &bytecode).unwrap();
+    let runtime = unsafe { RUNTIME.take().unwrap() };
+    execution::run_bytecode(&runtime, &bytecode).unwrap();
 }

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -1,0 +1,6 @@
+use anyhow::Result;
+use javy::{Config, Runtime};
+
+pub(crate) fn new_runtime() -> Result<Runtime> {
+    Runtime::new(Config::default())
+}

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -1,6 +1,5 @@
-use anyhow::Result;
-use javy::{Config, Runtime};
+use javy::Runtime;
 
-pub(crate) fn new_runtime() -> Result<Runtime> {
-    Runtime::new(Config::default())
+pub(crate) fn new_runtime() -> Runtime {
+    Runtime::default()
 }

--- a/crates/javy/src/config.rs
+++ b/crates/javy/src/config.rs
@@ -1,0 +1,10 @@
+/// A configuration for [`Runtime`](crate::Runtime)
+#[derive(Debug)]
+pub struct Config {}
+
+impl Default for Config {
+    /// Creates a [`Config`] with default values
+    fn default() -> Self {
+        Self {}
+    }
+}

--- a/crates/javy/src/config.rs
+++ b/crates/javy/src/config.rs
@@ -1,9 +1,9 @@
-/// A configuration for [`Runtime`](crate::Runtime)
+/// A configuration for [`Runtime`](crate::Runtime).
 #[derive(Debug)]
 pub struct Config {}
 
 impl Default for Config {
-    /// Creates a [`Config`] with default values
+    /// Creates a [`Config`] with default values.
     fn default() -> Self {
         Self {}
     }

--- a/crates/javy/src/lib.rs
+++ b/crates/javy/src/lib.rs
@@ -1,4 +1,4 @@
-//! Configurable JavaScript runtime for WebAssembly
+//! Configurable JavaScript runtime for WebAssembly.
 //!
 //! Example usage:
 //! ```

--- a/crates/javy/src/lib.rs
+++ b/crates/javy/src/lib.rs
@@ -1,1 +1,19 @@
+//! Configurable JavaScript runtime for WebAssembly
+//!
+//! Example usage:
+//! ```
+//! # use javy::{Config, Runtime};
+//! let runtime = Runtime::new(Config::default()).unwrap();
+//! runtime.context().eval_global("test.js", "console.log('hello world!');").unwrap();
+//! ```
+//!
+//! ## Core concepts
+//! * [`Runtime`] - The entrypoint for using the JavaScript runtime. Use a
+//!   [`Config`] to configure behavior.
+
+pub use config::Config;
 pub use quickjs_wasm_rs as quickjs;
+pub use runtime::Runtime;
+
+mod config;
+mod runtime;

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -31,3 +31,11 @@ impl Runtime {
         &self.context
     }
 }
+
+impl Default for Runtime {
+    /// Returns a [`Runtime`] with a default configuration. Panics if there's
+    /// an error.
+    fn default() -> Self {
+        Self::new(Config::default()).unwrap()
+    }
+}

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 
 use crate::Config;
 
-/// A JavaScript Runtime
+/// A JavaScript Runtime.
 ///
 /// Provides a [`Self::context()`] method for working with the underlying [`JSContextRef`].
 ///
@@ -20,13 +20,13 @@ pub struct Runtime {
 }
 
 impl Runtime {
-    /// Creates a new [`Runtime`]
+    /// Creates a new [`Runtime`].
     pub fn new(_config: Config) -> Result<Self> {
         let context = JSContextRef::default();
         Ok(Self { context })
     }
 
-    /// A reference to a [`JSContextRef`]
+    /// A reference to a [`JSContextRef`].
     pub fn context(&self) -> &JSContextRef {
         &self.context
     }

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -1,0 +1,33 @@
+use crate::quickjs::JSContextRef;
+use anyhow::Result;
+
+use crate::Config;
+
+/// A JavaScript Runtime
+///
+/// Provides a [`Self::context()`] method for working with the underlying [`JSContextRef`].
+///
+/// ## Examples
+///
+/// ```
+/// # use javy::{Config, Runtime};
+/// let runtime = Runtime::new(Config::default()).unwrap();
+/// runtime.context().eval_global("test.js", "console.log('hello world!');").unwrap();
+/// ```
+#[derive(Debug)]
+pub struct Runtime {
+    context: JSContextRef,
+}
+
+impl Runtime {
+    /// Creates a new [`Runtime`]
+    pub fn new(_config: Config) -> Result<Self> {
+        let context = JSContextRef::default();
+        Ok(Self { context })
+    }
+
+    /// A reference to a [`JSContextRef`]
+    pub fn context(&self) -> &JSContextRef {
+        &self.context
+    }
+}


### PR DESCRIPTION
Part of #310. Adds a `Runtime` and associated `Config` struct to the `javy` crate. Also switches the `core` crate to use `Runtime` instead of `JSContextRef` for a few things.

Run `cargo doc --package=javy --open --target=wasm32-wasi` to see generated documentation.