### PR TITLE
Add apis crate scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,6 +1069,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "javy-apis"
+version = "1.0.0-alpha1"
+dependencies = [
+ "anyhow",
+ "javy",
+]
+
+[[package]]
 name = "javy-cli"
 version = "0.6.0"
 dependencies = [
@@ -1099,6 +1107,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "javy",
+ "javy-apis",
  "once_cell",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "crates/quickjs-wasm-sys",
   "crates/quickjs-wasm-rs",
   "crates/javy",
+  "crates/apis",
   "crates/core",
   "crates/cli",
 ]

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ fmt-javy:
 	cargo fmt --package=javy -- --check
 	cargo clippy --package=javy --target=wasm32-wasi --all-targets -- -D warnings
 
-fmt-javy-apis:
+fmt-apis:
 	cargo fmt --package=javy-apis -- --check
 	cargo clippy --package=javy-apis --target=wasm32-wasi --all-targets -- -D warnings
 

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ test-quickjs-wasm-rs:
 test-javy:
 	cargo wasi test --package=javy -- --nocapture
 
+test-apis:
+	cargo wasi test --package=javy-apis -- --nocapture
+
 test-core:
 	cargo wasi test --package=javy-core -- --nocapture
 
@@ -46,9 +49,9 @@ test-wpt:
 	npm install --prefix wpt
 	npm test --prefix wpt 
 
-tests: test-quickjs-wasm-rs test-javy test-core test-cli test-wpt
+tests: test-quickjs-wasm-rs test-javy test-apis test-core test-cli test-wpt
 
-fmt: fmt-quickjs-wasm-sys fmt-quickjs-wasm-rs fmt-javy fmt-core fmt-cli
+fmt: fmt-quickjs-wasm-sys fmt-quickjs-wasm-rs fmt-javy fmt-apis fmt-core fmt-cli
 
 fmt-quickjs-wasm-sys:
 	cargo fmt --package=quickjs-wasm-sys -- --check
@@ -61,6 +64,10 @@ fmt-quickjs-wasm-rs:
 fmt-javy:
 	cargo fmt --package=javy -- --check
 	cargo clippy --package=javy --target=wasm32-wasi --all-targets -- -D warnings
+
+fmt-javy-apis:
+	cargo fmt --package=javy-apis -- --check
+	cargo clippy --package=javy-apis --target=wasm32-wasi --all-targets -- -D warnings
 
 fmt-core:
 	cargo fmt --package=javy-core -- --check

--- a/crates/apis/Cargo.toml
+++ b/crates/apis/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "javy-apis"
+version = "1.0.0-alpha1"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+javy = { path = "../javy" }

--- a/crates/apis/src/api_config.rs
+++ b/crates/apis/src/api_config.rs
@@ -1,0 +1,7 @@
+pub struct APIConfig {}
+
+impl Default for APIConfig {
+    fn default() -> Self {
+        Self {}
+    }
+}

--- a/crates/apis/src/api_config.rs
+++ b/crates/apis/src/api_config.rs
@@ -1,2 +1,3 @@
+/// A configuration for APIs added in this crate.
 #[derive(Debug, Default)]
 pub struct APIConfig {}

--- a/crates/apis/src/api_config.rs
+++ b/crates/apis/src/api_config.rs
@@ -1,7 +1,2 @@
+#[derive(Debug, Default)]
 pub struct APIConfig {}
-
-impl Default for APIConfig {
-    fn default() -> Self {
-        Self {}
-    }
-}

--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -25,6 +25,18 @@
 //! # Ok::<(), Error>(())
 //! ```
 
+#![deny(
+    missing_docs,
+    rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links,
+    rustdoc::missing_crate_level_docs,
+    rustdoc::private_doc_tests,
+    rustdoc::invalid_codeblock_attributes,
+    rustdoc::invalid_html_tags,
+    rustdoc::invalid_rust_codeblocks,
+    rustdoc::bare_urls
+)]
+
 use anyhow::Result;
 use javy::Runtime;
 

--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -1,7 +1,34 @@
+//! JS APIs for Javy.
+//!
+//! This crate provides JS APIs you can add to Javy.
+//!
+//! Example usage:
+//! ```
+//! # use anyhow::{anyhow, Error, Result};
+//! use javy::{quickjs::JSValue, Runtime};
+//! use javy_apis::RuntimeExt;
+//!
+//! let runtime = Runtime::new_with_defaults()?;
+//! let context = runtime.context();
+//! context.global_object()?.set_property(
+//!    "print",
+//!    context.wrap_callback(move |_ctx, _this, args| {
+//!        let str = args
+//!            .first()
+//!            .ok_or(anyhow!("Need to pass an argument"))?
+//!            .to_string();
+//!        println!("{str}");
+//!        Ok(JSValue::Undefined)
+//!    })?,
+//! )?;
+//! context.eval_global("hello.js", "print('hello!');")?;
+//! # Ok::<(), Error>(())
+//! ```
+
 use anyhow::Result;
-use api_config::APIConfig;
 use javy::Runtime;
 
+pub use api_config::APIConfig;
 pub use runtime_ext::RuntimeExt;
 
 mod api_config;
@@ -11,6 +38,17 @@ pub(crate) trait JSApiSet {
     fn register(&self, runtime: &Runtime, config: APIConfig) -> Result<()>;
 }
 
+/// Adds enabled JS APIs to the provided [`Runtime`].
+///
+/// ## Example
+/// ```
+/// # use anyhow::Error;
+/// # use javy::Runtime;
+/// # use javy_apis::APIConfig;
+/// let runtime = Runtime::default();
+/// javy_apis::add_to_runtime(&runtime, APIConfig::default())?;
+/// # Ok::<(), Error>(())
+/// ```
 pub fn add_to_runtime(_runtime: &Runtime, _config: APIConfig) -> Result<()> {
     Ok(())
 }

--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -25,18 +25,6 @@
 //! # Ok::<(), Error>(())
 //! ```
 
-#![deny(
-    missing_docs,
-    rustdoc::broken_intra_doc_links,
-    rustdoc::private_intra_doc_links,
-    rustdoc::missing_crate_level_docs,
-    rustdoc::private_doc_tests,
-    rustdoc::invalid_codeblock_attributes,
-    rustdoc::invalid_html_tags,
-    rustdoc::invalid_rust_codeblocks,
-    rustdoc::bare_urls
-)]
-
 use anyhow::Result;
 use javy::Runtime;
 

--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use api_config::APIConfig;
+use javy::Runtime;
+
+pub use runtime_ext::RuntimeExt;
+
+mod api_config;
+mod runtime_ext;
+
+pub(crate) trait JSApiSet {
+    fn register(&self, runtime: &Runtime, config: APIConfig) -> Result<()>;
+}
+
+pub fn add_to_runtime(_runtime: &Runtime, _config: APIConfig) -> Result<()> {
+    Ok(())
+}

--- a/crates/apis/src/runtime_ext.rs
+++ b/crates/apis/src/runtime_ext.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+use javy::{Config, Runtime};
+
+use crate::APIConfig;
+
+pub trait RuntimeExt {
+    fn new_with_apis(config: Config, api_config: APIConfig) -> Result<Runtime>;
+    fn new_with_defaults() -> Result<Runtime>;
+}
+
+impl RuntimeExt for Runtime {
+    fn new_with_apis(config: Config, api_config: APIConfig) -> Result<Runtime> {
+        let runtime = Runtime::new(config)?;
+        crate::add_to_runtime(&runtime, api_config)?;
+        Ok(runtime)
+    }
+
+    fn new_with_defaults() -> Result<Runtime> {
+        Self::new_with_apis(Config::default(), APIConfig::default())
+    }
+}

--- a/crates/apis/src/runtime_ext.rs
+++ b/crates/apis/src/runtime_ext.rs
@@ -15,7 +15,10 @@ use crate::APIConfig;
 /// # Ok::<(), Error>(())
 /// ```
 pub trait RuntimeExt {
+    /// Creates a [`Runtime`] configured by the provided [`Config`] with JS
+    /// APIs added configured according to the [`APIConfig`].
     fn new_with_apis(config: Config, api_config: APIConfig) -> Result<Runtime>;
+    /// Creates a [`Runtime`] with JS APIs added with a default configuration.
     fn new_with_defaults() -> Result<Runtime>;
 }
 

--- a/crates/apis/src/runtime_ext.rs
+++ b/crates/apis/src/runtime_ext.rs
@@ -3,6 +3,17 @@ use javy::{Config, Runtime};
 
 use crate::APIConfig;
 
+/// A extension trait for [`Runtime`] that creates a [`Runtime`] with APIs
+/// provided in this crate.
+///
+/// ## Example
+/// ```
+/// # use anyhow::Error;
+/// use javy::Runtime;
+/// use javy_apis::RuntimeExt;
+/// let runtime = Runtime::new_with_defaults()?;
+/// # Ok::<(), Error>(())
+/// ```
 pub trait RuntimeExt {
     fn new_with_apis(config: Config, api_config: APIConfig) -> Result<Runtime>;
     fn new_with_defaults() -> Result<Runtime>;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = { workspace = true }
 javy = { path = "../javy" }
+javy-apis = { path = "../apis" }
 once_cell = { workspace = true }
 
 [features]

--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -180,7 +180,7 @@ mod tests {
     fn test_console_log() -> Result<()> {
         let mut stream = SharedStream::default();
 
-        let runtime = runtime::new_runtime();
+        let runtime = runtime::new_runtime()?;
         let ctx = runtime.context();
         inject_javy_globals(&runtime, stream.clone(), stream.clone())?;
 
@@ -209,7 +209,7 @@ mod tests {
     fn test_console_error() -> Result<()> {
         let mut stream = SharedStream::default();
 
-        let runtime = runtime::new_runtime();
+        let runtime = runtime::new_runtime()?;
         let ctx = runtime.context();
         inject_javy_globals(&runtime, stream.clone(), stream.clone())?;
 
@@ -237,7 +237,7 @@ mod tests {
     #[test]
     fn test_text_encoder_decoder() -> Result<()> {
         let stream = SharedStream::default();
-        let runtime = runtime::new_runtime();
+        let runtime = runtime::new_runtime()?;
         let ctx = runtime.context();
         inject_javy_globals(&runtime, stream.clone(), stream.clone())?;
         ctx.eval_global(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -23,7 +23,7 @@ static mut RUNTIME: OnceCell<Runtime> = OnceCell::new();
 /// Used by Wizer to preinitialize the module
 #[export_name = "wizer.initialize"]
 pub extern "C" fn init() {
-    let runtime = runtime::new_runtime();
+    let runtime = runtime::new_runtime().unwrap();
     globals::inject_javy_globals(&runtime, io::stderr(), io::stderr()).unwrap();
     unsafe { RUNTIME.set(runtime).unwrap() };
 }
@@ -44,7 +44,7 @@ pub extern "C" fn init() {
 #[export_name = "compile_src"]
 pub unsafe extern "C" fn compile_src(js_src_ptr: *const u8, js_src_len: usize) -> *const u32 {
     // Use fresh runtime to avoid depending on Wizened runtime
-    let runtime = runtime::new_runtime();
+    let runtime = runtime::new_runtime().unwrap();
     let js_src = str::from_utf8(slice::from_raw_parts(js_src_ptr, js_src_len)).unwrap();
     let bytecode = runtime
         .context()

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -12,7 +12,7 @@ static mut BYTECODE: OnceCell<Vec<u8>> = OnceCell::new();
 
 #[export_name = "wizer.initialize"]
 pub extern "C" fn init() {
-    let runtime = runtime::new_runtime();
+    let runtime = runtime::new_runtime().unwrap();
     globals::inject_javy_globals(&runtime, io::stderr(), io::stderr()).unwrap();
 
     let mut contents = String::new();

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -1,5 +1,7 @@
+use anyhow::Result;
 use javy::Runtime;
+use javy_apis::RuntimeExt;
 
-pub(crate) fn new_runtime() -> Runtime {
-    Runtime::default()
+pub(crate) fn new_runtime() -> Result<Runtime> {
+    Runtime::new_with_defaults()
 }


### PR DESCRIPTION
Part of #310. Adds scaffolding for the `javy-apis` crate that will eventually hold `core`'s implementations of console, stream IO, and text encoding APIs.