### PR TITLE
register should take APIConfig as a reference

### DIFF
--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -35,7 +35,7 @@ mod api_config;
 mod runtime_ext;
 
 pub(crate) trait JSApiSet {
-    fn register(&self, runtime: &Runtime, config: APIConfig) -> Result<()>;
+    fn register(&self, runtime: &Runtime, config: &APIConfig) -> Result<()>;
 }
 
 /// Adds enabled JS APIs to the provided [`Runtime`].


### PR DESCRIPTION
Part of #310. I realized that the `register` method on `JSApiSet` needs to take `APIConfig` as a reference so we can pass it to multiple API sets.