### PR TITLE
quickjs-wasm-rs v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-rs"
-version = "1.0.0-alpha.3"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/crates/quickjs-wasm-rs/CHANGELOG.md
+++ b/crates/quickjs-wasm-rs/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2023-05-02
+
+### Added
+- Documentation across the crate.
+- Added an enum `JSValue` that represents a JavaScript value that can convert to and from Rust types with `try_into`.
+
+### Changed
+- Renamed `Value` to `JSValueRef`.
+- Renamed `Context` to `JSContextRef`.
+- Callback functions now work with `CallbackArg` instead of `JSValueRef` directly. `CallbackArg` can easily convert to Rust types with `try_into`.
+- Relationship of `JSValueRef` and `JSContextRef` is now safer with `JSValueRef` containing a reference to `JSContextRef` instead of a raw pointer to the quickjs `JSContext`.
+
+
+[unreleased]: https://github.com/Shopify/javy/compare/quickjs-wasm-rs-1.0.0...HEAD
+[1.0.0]: https://github.com/Shopify/javy/tree/quickjs-wasm-rs-1.0.0/crates/quickjs-wasm-rs
+

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-rs"
-version = "1.0.0-alpha.3"
+version = "1.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Closes https://github.com/Shopify/javy/issues/295

Bump the version to v1.0.0 and add a changelog.

If this looks good, I'll publish to crates.io after merging.