### PR TITLE
Move console API to apis crate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test-javy:
 	cargo wasi test --package=javy -- --nocapture
 
 test-apis:
-	cargo wasi test --package=javy-apis -- --nocapture
+	cargo wasi test --package=javy-apis --features console -- --nocapture
 
 test-core:
 	cargo wasi test --package=javy-core -- --nocapture
@@ -67,7 +67,7 @@ fmt-javy:
 
 fmt-apis:
 	cargo fmt --package=javy-apis -- --check
-	cargo clippy --package=javy-apis --target=wasm32-wasi --all-targets -- -D warnings
+	cargo clippy --package=javy-apis --features console --target=wasm32-wasi --all-targets -- -D warnings
 
 fmt-core:
 	cargo fmt --package=javy-core -- --check

--- a/crates/apis/Cargo.toml
+++ b/crates/apis/Cargo.toml
@@ -5,6 +5,9 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+console = []
+
 [dependencies]
 anyhow = { workspace = true }
 javy = { path = "../javy" }

--- a/crates/apis/src/api_config.rs
+++ b/crates/apis/src/api_config.rs
@@ -1,3 +1,64 @@
+use std::io::{self, Write};
+
+#[cfg(feature = "console")]
+/// A selection of possible destination streams for `console.log` and
+/// `console.error`.
+#[derive(Debug)]
+pub enum LogStream {
+    /// The standard output stream.
+    StdOut,
+    /// The standard error stream.
+    StdErr,
+}
+
+#[cfg(feature = "console")]
+impl LogStream {
+    pub(crate) fn as_stream(&self) -> Box<dyn Write + 'static> {
+        match self {
+            Self::StdErr => Box::new(io::stderr()),
+            Self::StdOut => Box::new(io::stdout()),
+        }
+    }
+}
+
 /// A configuration for APIs added in this crate.
-#[derive(Debug, Default)]
-pub struct APIConfig {}
+///
+/// Example usage:
+/// ```
+/// # use javy_apis::{APIConfig, LogStream};
+/// let api_config = APIConfig::default();
+/// ```
+#[derive(Debug)]
+pub struct APIConfig {
+    #[cfg(feature = "console")]
+    pub(crate) log_stream: LogStream,
+    #[cfg(feature = "console")]
+    pub(crate) error_stream: LogStream,
+}
+
+impl APIConfig {
+    #[cfg(feature = "console")]
+    /// Sets the destination stream for `console.log`.
+    pub fn log_stream(&mut self, stream: LogStream) -> &mut Self {
+        self.log_stream = stream;
+        self
+    }
+
+    #[cfg(feature = "console")]
+    /// Sets the destination stream for `console.error`.
+    pub fn error_stream(&mut self, stream: LogStream) -> &mut Self {
+        self.error_stream = stream;
+        self
+    }
+}
+
+impl Default for APIConfig {
+    fn default() -> Self {
+        Self {
+            #[cfg(feature = "console")]
+            log_stream: LogStream::StdOut,
+            #[cfg(feature = "console")]
+            error_stream: LogStream::StdErr,
+        }
+    }
+}

--- a/crates/apis/src/api_config.rs
+++ b/crates/apis/src/api_config.rs
@@ -25,7 +25,7 @@ impl LogStream {
 ///
 /// Example usage:
 /// ```
-/// # use javy_apis::{APIConfig, LogStream};
+/// # use javy_apis::APIConfig;
 /// let api_config = APIConfig::default();
 /// ```
 #[derive(Debug)]

--- a/crates/apis/src/api_config.rs
+++ b/crates/apis/src/api_config.rs
@@ -13,7 +13,7 @@ pub enum LogStream {
 
 #[cfg(feature = "console")]
 impl LogStream {
-    pub(crate) fn as_stream(&self) -> Box<dyn Write + 'static> {
+    pub(crate) fn to_stream(&self) -> Box<dyn Write + 'static> {
         match self {
             Self::StdErr => Box::new(io::stderr()),
             Self::StdOut => Box::new(io::stdout()),

--- a/crates/apis/src/api_config.rs
+++ b/crates/apis/src/api_config.rs
@@ -8,5 +8,5 @@
 #[derive(Debug, Default)]
 pub struct APIConfig {
     #[cfg(feature = "console")]
-    pub(crate) console: crate::ConsoleConfig,
+    pub(crate) console: crate::console::ConsoleConfig,
 }

--- a/crates/apis/src/api_config.rs
+++ b/crates/apis/src/api_config.rs
@@ -1,26 +1,3 @@
-use std::io::{self, Write};
-
-#[cfg(feature = "console")]
-/// A selection of possible destination streams for `console.log` and
-/// `console.error`.
-#[derive(Debug)]
-pub enum LogStream {
-    /// The standard output stream.
-    StdOut,
-    /// The standard error stream.
-    StdErr,
-}
-
-#[cfg(feature = "console")]
-impl LogStream {
-    pub(crate) fn to_stream(&self) -> Box<dyn Write + 'static> {
-        match self {
-            Self::StdErr => Box::new(io::stderr()),
-            Self::StdOut => Box::new(io::stdout()),
-        }
-    }
-}
-
 /// A configuration for APIs added in this crate.
 ///
 /// Example usage:
@@ -28,37 +5,8 @@ impl LogStream {
 /// # use javy_apis::APIConfig;
 /// let api_config = APIConfig::default();
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct APIConfig {
     #[cfg(feature = "console")]
-    pub(crate) log_stream: LogStream,
-    #[cfg(feature = "console")]
-    pub(crate) error_stream: LogStream,
-}
-
-impl APIConfig {
-    #[cfg(feature = "console")]
-    /// Sets the destination stream for `console.log`.
-    pub fn log_stream(&mut self, stream: LogStream) -> &mut Self {
-        self.log_stream = stream;
-        self
-    }
-
-    #[cfg(feature = "console")]
-    /// Sets the destination stream for `console.error`.
-    pub fn error_stream(&mut self, stream: LogStream) -> &mut Self {
-        self.error_stream = stream;
-        self
-    }
-}
-
-impl Default for APIConfig {
-    fn default() -> Self {
-        Self {
-            #[cfg(feature = "console")]
-            log_stream: LogStream::StdOut,
-            #[cfg(feature = "console")]
-            error_stream: LogStream::StdErr,
-        }
-    }
+    pub(crate) console: crate::ConsoleConfig,
 }

--- a/crates/apis/src/console.rs
+++ b/crates/apis/src/console.rs
@@ -20,8 +20,8 @@ impl JSApiSet for Console {
     fn register(&self, runtime: &Runtime, config: &APIConfig) -> Result<()> {
         register_console(
             runtime.context(),
-            config.log_stream.as_stream(),
-            config.error_stream.as_stream(),
+            config.log_stream.to_stream(),
+            config.error_stream.to_stream(),
         )
     }
 }

--- a/crates/apis/src/console.rs
+++ b/crates/apis/src/console.rs
@@ -1,0 +1,182 @@
+use std::io::Write;
+
+use anyhow::Result;
+use javy::{
+    quickjs::{CallbackArg, JSContextRef, JSValue},
+    Runtime,
+};
+
+use crate::{APIConfig, JSApiSet};
+
+pub(crate) struct Console {}
+
+impl Console {
+    pub(crate) fn new() -> Self {
+        Console {}
+    }
+}
+
+impl JSApiSet for Console {
+    fn register(&self, runtime: &Runtime, config: &APIConfig) -> Result<()> {
+        register_console(
+            runtime.context(),
+            config.log_stream.as_stream(),
+            config.error_stream.as_stream(),
+        )
+    }
+}
+
+fn register_console<T, U>(context: &JSContextRef, log_stream: T, error_stream: U) -> Result<()>
+where
+    T: Write + 'static,
+    U: Write + 'static,
+{
+    let console_log_callback = context.wrap_callback(console_log_to(log_stream))?;
+    let console_error_callback = context.wrap_callback(console_log_to(error_stream))?;
+    let console_object = context.object_value()?;
+    console_object.set_property("log", console_log_callback)?;
+    console_object.set_property("error", console_error_callback)?;
+    context
+        .global_object()?
+        .set_property("console", console_object)?;
+    Ok(())
+}
+
+fn console_log_to<T>(
+    mut stream: T,
+) -> impl FnMut(&JSContextRef, &CallbackArg, &[CallbackArg]) -> Result<JSValue>
+where
+    T: Write + 'static,
+{
+    move |_ctx: &JSContextRef, _this: &CallbackArg, args: &[CallbackArg]| {
+        // Write full string to in-memory destination before writing to stream since each write call to the stream
+        // will invoke a hostcall.
+        let mut log_line = String::new();
+        for (i, arg) in args.iter().enumerate() {
+            if i != 0 {
+                log_line.push(' ');
+            }
+            let line = arg.to_string();
+            log_line.push_str(&line);
+        }
+
+        writeln!(stream, "{log_line}")?;
+
+        Ok(JSValue::Undefined)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use javy::Runtime;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    use std::{cmp, io};
+
+    use crate::console::register_console;
+    use crate::{APIConfig, JSApiSet};
+
+    use super::Console;
+
+    #[test]
+    fn test_register() -> Result<()> {
+        let runtime = Runtime::default();
+        Console::new().register(&runtime, &APIConfig::default())?;
+        let console = runtime.context().global_object()?.get_property("console")?;
+        assert!(console.get_property("log").is_ok());
+        assert!(console.get_property("error").is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn test_console_log() -> Result<()> {
+        let mut stream = SharedStream::default();
+
+        let runtime = Runtime::default();
+        let ctx = runtime.context();
+        register_console(ctx, stream.clone(), stream.clone())?;
+
+        ctx.eval_global("main", "console.log(\"hello world\");")?;
+        assert_eq!(b"hello world\n", stream.buffer.borrow().as_slice());
+
+        stream.clear();
+
+        ctx.eval_global("main", "console.log(\"bonjour\", \"le\", \"monde\")")?;
+        assert_eq!(b"bonjour le monde\n", stream.buffer.borrow().as_slice());
+
+        stream.clear();
+
+        ctx.eval_global(
+            "main",
+            "console.log(2.3, true, { foo: 'bar' }, null, undefined)",
+        )?;
+        assert_eq!(
+            b"2.3 true [object Object] null undefined\n",
+            stream.buffer.borrow().as_slice()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_console_error() -> Result<()> {
+        let mut stream = SharedStream::default();
+
+        let runtime = Runtime::default();
+        let ctx = runtime.context();
+        register_console(ctx, stream.clone(), stream.clone())?;
+
+        ctx.eval_global("main", "console.error(\"hello world\");")?;
+        assert_eq!(b"hello world\n", stream.buffer.borrow().as_slice());
+
+        stream.clear();
+
+        ctx.eval_global("main", "console.error(\"bonjour\", \"le\", \"monde\")")?;
+        assert_eq!(b"bonjour le monde\n", stream.buffer.borrow().as_slice());
+
+        stream.clear();
+
+        ctx.eval_global(
+            "main",
+            "console.error(2.3, true, { foo: 'bar' }, null, undefined)",
+        )?;
+        assert_eq!(
+            b"2.3 true [object Object] null undefined\n",
+            stream.buffer.borrow().as_slice()
+        );
+        Ok(())
+    }
+
+    #[derive(Clone)]
+    struct SharedStream {
+        buffer: Rc<RefCell<Vec<u8>>>,
+        capacity: usize,
+    }
+
+    impl Default for SharedStream {
+        fn default() -> Self {
+            Self {
+                buffer: Default::default(),
+                capacity: usize::MAX,
+            }
+        }
+    }
+
+    impl SharedStream {
+        fn clear(&mut self) {
+            (*self.buffer).borrow_mut().clear();
+        }
+    }
+
+    impl io::Write for SharedStream {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            let available_capacity = self.capacity - (*self.buffer).borrow().len();
+            let leftover = cmp::min(available_capacity, buf.len());
+            (*self.buffer).borrow_mut().write(&buf[..leftover])
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            (*self.buffer).borrow_mut().flush()
+        }
+    }
+}

--- a/crates/apis/src/console/config.rs
+++ b/crates/apis/src/console/config.rs
@@ -1,0 +1,59 @@
+use std::io::{self, Write};
+
+use crate::APIConfig;
+
+/// A selection of possible destination streams for `console.log` and
+/// `console.error`.
+#[derive(Debug)]
+pub enum LogStream {
+    /// The standard output stream.
+    StdOut,
+    /// The standard error stream.
+    StdErr,
+}
+
+impl LogStream {
+    pub(super) fn to_stream(&self) -> Box<dyn Write + 'static> {
+        match self {
+            Self::StdErr => Box::new(io::stderr()),
+            Self::StdOut => Box::new(io::stdout()),
+        }
+    }
+}
+
+/// A configuration for the `console` JS API.
+#[derive(Debug)]
+pub struct ConsoleConfig {
+    pub(super) log_stream: LogStream,
+    pub(super) error_stream: LogStream,
+}
+
+impl ConsoleConfig {
+    /// Sets the destination stream for `console.log`.
+    pub fn log_stream(&mut self, stream: LogStream) -> &mut Self {
+        self.log_stream = stream;
+        self
+    }
+
+    /// Sets the destination stream for `console.error`.
+    pub fn error_stream(&mut self, stream: LogStream) -> &mut Self {
+        self.error_stream = stream;
+        self
+    }
+}
+
+impl Default for ConsoleConfig {
+    fn default() -> Self {
+        Self {
+            log_stream: LogStream::StdOut,
+            error_stream: LogStream::StdErr,
+        }
+    }
+}
+
+impl APIConfig {
+    /// Sets the destination stream for `console.log`.
+    pub fn console(&mut self) -> &mut ConsoleConfig {
+        &mut self.console
+    }
+}

--- a/crates/apis/src/console/config.rs
+++ b/crates/apis/src/console/config.rs
@@ -21,25 +21,10 @@ impl LogStream {
     }
 }
 
-/// A configuration for the `console` JS API.
 #[derive(Debug)]
-pub struct ConsoleConfig {
+pub(crate) struct ConsoleConfig {
     pub(super) log_stream: LogStream,
     pub(super) error_stream: LogStream,
-}
-
-impl ConsoleConfig {
-    /// Sets the destination stream for `console.log`.
-    pub fn log_stream(&mut self, stream: LogStream) -> &mut Self {
-        self.log_stream = stream;
-        self
-    }
-
-    /// Sets the destination stream for `console.error`.
-    pub fn error_stream(&mut self, stream: LogStream) -> &mut Self {
-        self.error_stream = stream;
-        self
-    }
 }
 
 impl Default for ConsoleConfig {
@@ -53,7 +38,14 @@ impl Default for ConsoleConfig {
 
 impl APIConfig {
     /// Sets the destination stream for `console.log`.
-    pub fn console(&mut self) -> &mut ConsoleConfig {
-        &mut self.console
+    pub fn log_stream(&mut self, stream: LogStream) -> &mut Self {
+        self.console.log_stream = stream;
+        self
+    }
+
+    /// Sets the destination stream for `console.error`.
+    pub fn error_stream(&mut self, stream: LogStream) -> &mut Self {
+        self.console.error_stream = stream;
+        self
     }
 }

--- a/crates/apis/src/console/mod.rs
+++ b/crates/apis/src/console/mod.rs
@@ -8,7 +8,8 @@ use javy::{
 
 use crate::{APIConfig, JSApiSet};
 
-pub use config::{ConsoleConfig, LogStream};
+pub(super) use config::ConsoleConfig;
+pub use config::LogStream;
 
 mod config;
 

--- a/crates/apis/src/console/mod.rs
+++ b/crates/apis/src/console/mod.rs
@@ -8,10 +8,14 @@ use javy::{
 
 use crate::{APIConfig, JSApiSet};
 
-pub(crate) struct Console {}
+pub use config::{ConsoleConfig, LogStream};
+
+mod config;
+
+pub(super) struct Console {}
 
 impl Console {
-    pub(crate) fn new() -> Self {
+    pub(super) fn new() -> Self {
         Console {}
     }
 }
@@ -20,8 +24,8 @@ impl JSApiSet for Console {
     fn register(&self, runtime: &Runtime, config: &APIConfig) -> Result<()> {
         register_console(
             runtime.context(),
-            config.log_stream.to_stream(),
-            config.error_stream.to_stream(),
+            config.console.log_stream.to_stream(),
+            config.console.error_stream.to_stream(),
         )
     }
 }

--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -28,14 +28,21 @@
 use anyhow::Result;
 use javy::Runtime;
 
+#[cfg(feature = "console")]
+use console::Console;
+
 pub use api_config::APIConfig;
+#[cfg(feature = "console")]
+pub use api_config::LogStream;
 pub use runtime_ext::RuntimeExt;
 
 mod api_config;
+#[cfg(feature = "console")]
+mod console;
 mod runtime_ext;
 
 pub(crate) trait JSApiSet {
-    fn register(&self, runtime: &Runtime, config: APIConfig) -> Result<()>;
+    fn register(&self, runtime: &Runtime, config: &APIConfig) -> Result<()>;
 }
 
 /// Adds enabled JS APIs to the provided [`Runtime`].
@@ -49,6 +56,8 @@ pub(crate) trait JSApiSet {
 /// javy_apis::add_to_runtime(&runtime, APIConfig::default())?;
 /// # Ok::<(), Error>(())
 /// ```
-pub fn add_to_runtime(_runtime: &Runtime, _config: APIConfig) -> Result<()> {
+pub fn add_to_runtime(runtime: &Runtime, config: APIConfig) -> Result<()> {
+    #[cfg(feature = "console")]
+    Console::new().register(runtime, &config)?;
     Ok(())
 }

--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -28,12 +28,9 @@
 use anyhow::Result;
 use javy::Runtime;
 
-#[cfg(feature = "console")]
-use console::Console;
-
 pub use api_config::APIConfig;
 #[cfg(feature = "console")]
-pub use api_config::LogStream;
+pub use console::{ConsoleConfig, LogStream};
 pub use runtime_ext::RuntimeExt;
 
 mod api_config;
@@ -58,6 +55,6 @@ pub(crate) trait JSApiSet {
 /// ```
 pub fn add_to_runtime(runtime: &Runtime, config: APIConfig) -> Result<()> {
     #[cfg(feature = "console")]
-    Console::new().register(runtime, &config)?;
+    console::Console::new().register(runtime, &config)?;
     Ok(())
 }

--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -30,7 +30,7 @@ use javy::Runtime;
 
 pub use api_config::APIConfig;
 #[cfg(feature = "console")]
-pub use console::{ConsoleConfig, LogStream};
+pub use console::LogStream;
 pub use runtime_ext::RuntimeExt;
 
 mod api_config;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = { workspace = true }
 javy = { path = "../javy" }
-javy-apis = { path = "../apis" }
+javy-apis = { path = "../apis", features = ["console"] }
 once_cell = { workspace = true }
 
 [features]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,7 +1,6 @@
 use javy::Runtime;
 use once_cell::sync::OnceCell;
 use std::alloc::{alloc, dealloc, Layout};
-use std::io;
 use std::ptr::copy_nonoverlapping;
 use std::slice;
 use std::str;
@@ -24,7 +23,7 @@ static mut RUNTIME: OnceCell<Runtime> = OnceCell::new();
 #[export_name = "wizer.initialize"]
 pub extern "C" fn init() {
     let runtime = runtime::new_runtime().unwrap();
-    globals::inject_javy_globals(&runtime, io::stderr(), io::stderr()).unwrap();
+    globals::inject_javy_globals(&runtime).unwrap();
     unsafe { RUNTIME.set(runtime).unwrap() };
 }
 

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -13,7 +13,7 @@ static mut BYTECODE: OnceCell<Vec<u8>> = OnceCell::new();
 #[export_name = "wizer.initialize"]
 pub extern "C" fn init() {
     let runtime = runtime::new_runtime().unwrap();
-    globals::inject_javy_globals(&runtime, io::stderr(), io::stderr()).unwrap();
+    globals::inject_javy_globals(&runtime).unwrap();
 
     let mut contents = String::new();
     io::stdin().read_to_string(&mut contents).unwrap();

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -4,6 +4,6 @@ use javy_apis::{APIConfig, LogStream, RuntimeExt};
 
 pub(crate) fn new_runtime() -> Result<Runtime> {
     let mut api_config = APIConfig::default();
-    api_config.log_stream(LogStream::StdErr);
+    api_config.console().log_stream(LogStream::StdErr);
     Runtime::new_with_apis(Config::default(), api_config)
 }

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -4,6 +4,6 @@ use javy_apis::{APIConfig, LogStream, RuntimeExt};
 
 pub(crate) fn new_runtime() -> Result<Runtime> {
     let mut api_config = APIConfig::default();
-    api_config.console().log_stream(LogStream::StdErr);
+    api_config.log_stream(LogStream::StdErr);
     Runtime::new_with_apis(Config::default(), api_config)
 }

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
-use javy::Runtime;
-use javy_apis::RuntimeExt;
+use javy::{Config, Runtime};
+use javy_apis::{APIConfig, LogStream, RuntimeExt};
 
 pub(crate) fn new_runtime() -> Result<Runtime> {
-    Runtime::new_with_defaults()
+    let mut api_config = APIConfig::default();
+    api_config.log_stream(LogStream::StdErr);
+    Runtime::new_with_apis(Config::default(), api_config)
 }


### PR DESCRIPTION
Part of #310. Moves the `console` API from `javy-core` to `javy-apis`.