### PR TITLE
Clarify make commands must be run in this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We will only add JS APIs or accept contributions that add JS APIs that are poten
   install cmake`
 - Rosetta 2 if running MacOS on Apple Silicon, can be installed via
   `softwareupdate --install-rosetta`
-- Install the `wasi-sdk` by running `make download-wasi-sdk`
+- Install the `wasi-sdk` by running `make download-wasi-sdk` in the top-level directory in this repository
 
 ## Development
 
@@ -39,8 +39,8 @@ We will only add JS APIs or accept contributions that add JS APIs that are poten
 
 ## Building
 
-After all the dependencies are installed, run `make`. You
-should now have access to the executable in `target/release/javy`
+After all the dependencies are installed, run `make` in the top-level directory of this repository. You
+should now have access to the executable in `target/release/javy`.
 
 Alternatively you can run `make && cargo install --path crates/cli`.
 After running the previous command you'll have a global installation of the


### PR DESCRIPTION
This should mitigate misunderstandings like in https://github.com/Shopify/javy/issues/342 about where to run the `make` commands.