### PR TITLE
Move json and msgpack modules from quickjs-wasm-rs to javy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,9 @@ version = "1.0.0-alpha1"
 dependencies = [
  "anyhow",
  "quickjs-wasm-rs",
+ "rmp-serde",
+ "serde-transcode",
+ "serde_json",
 ]
 
 [[package]]
@@ -1444,17 +1447,14 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-rs"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 dependencies = [
  "anyhow",
  "once_cell",
  "quickcheck",
  "quickjs-wasm-sys",
- "rmp-serde",
  "serde",
- "serde-transcode",
  "serde_bytes",
- "serde_json",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ docs:
 	cargo doc --package=javy-core --open --target=wasm32-wasi
 
 test-quickjs-wasm-rs:
-	cargo wasi test --package=quickjs-wasm-rs --features json,messagepack -- --nocapture
+	cargo wasi test --package=quickjs-wasm-rs -- --nocapture
 
 test-javy:
-	cargo wasi test --package=javy -- --nocapture
+	cargo wasi test --package=javy --features json,messagepack -- --nocapture
 
 test-apis:
 	cargo wasi test --package=javy-apis -- --nocapture

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -12,3 +12,10 @@ categories = ["wasm"]
 [dependencies]
 anyhow = { workspace = true }
 quickjs-wasm-rs = { version = "1.0.0-alpha.2", path = "../quickjs-wasm-rs" }
+serde_json = { version = "1.0", optional = true }
+serde-transcode = { version = "1.1", optional = true }
+rmp-serde = { version = "^1.1", optional = true }
+
+[features]
+messagepack = ["rmp-serde", "serde-transcode"]
+json = ["serde_json", "serde-transcode"]

--- a/crates/javy/src/json.rs
+++ b/crates/javy/src/json.rs
@@ -1,7 +1,5 @@
-use crate::serialize::de::Deserializer;
-use crate::serialize::ser::Serializer;
-use crate::{JSContextRef, JSValueRef};
 use anyhow::Result;
+use quickjs_wasm_rs::{Deserializer, JSContextRef, JSValueRef, Serializer};
 
 pub fn transcode_input<'a>(context: &'a JSContextRef, bytes: &[u8]) -> Result<JSValueRef<'a>> {
     let mut deserializer = serde_json::Deserializer::from_slice(bytes);

--- a/crates/javy/src/lib.rs
+++ b/crates/javy/src/lib.rs
@@ -36,3 +36,9 @@ pub use runtime::Runtime;
 
 mod config;
 mod runtime;
+
+#[cfg(feature = "messagepack")]
+pub mod messagepack;
+
+#[cfg(feature = "json")]
+pub mod json;

--- a/crates/javy/src/messagepack.rs
+++ b/crates/javy/src/messagepack.rs
@@ -1,7 +1,5 @@
-use crate::serialize::de::Deserializer;
-use crate::serialize::ser::Serializer;
-use crate::{JSContextRef, JSValueRef};
 use anyhow::Result;
+use quickjs_wasm_rs::{Deserializer, JSContextRef, JSValueRef, Serializer};
 
 pub fn transcode_input<'a>(context: &'a JSContextRef, bytes: &[u8]) -> Result<JSValueRef<'a>> {
     let mut deserializer = rmp_serde::Deserializer::from_read_ref(bytes);

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-rs"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -12,16 +12,9 @@ categories = ["api-bindings"]
 [dependencies]
 anyhow = { workspace = true }
 quickjs-wasm-sys = { version = "0.1.2", path = "../quickjs-wasm-sys" }
-rmp-serde = { version = "^1.1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", optional = true }
-serde-transcode = { version = "1.1", optional = true }
 once_cell = "1.16"
 
 [dev-dependencies]
 quickcheck = "1"
 serde_bytes = "0.11.7"
-
-[features]
-messagepack = ["rmp-serde", "serde-transcode"]
-json = ["serde_json", "serde-transcode"]

--- a/crates/quickjs-wasm-rs/src/lib.rs
+++ b/crates/quickjs-wasm-rs/src/lib.rs
@@ -74,9 +74,3 @@ pub use crate::js_value::qjs_convert::*;
 pub use crate::js_value::{CallbackArg, JSValue};
 pub use crate::serialize::de::Deserializer;
 pub use crate::serialize::ser::Serializer;
-
-#[cfg(feature = "messagepack")]
-pub mod messagepack;
-
-#[cfg(feature = "json")]
-pub mod json;


### PR DESCRIPTION
It makes more sense for these modules to be under the `javy` crate since `javy` uses `quickjs-wasm-rs` anyway. And we don't have to duplicate managing the feature flags by moving it under `javy`. It also makes the `quickjs-wasm-rs` crate less bloated.