### PR TITLE
Force LF line endings in shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,9 @@
 crates/quickjs-wasm-sys/quickjs/* linguist-vendored
+
+# Some people try to run shell scripts in WSL after cloning the repo in Windows.
+# If they clone the repo in Windows and the default `core.autocrlf` settings
+# are used, the shell script line endings are converted to Windows line
+# endings. When they try to run the script with Windows line endings in WSL,
+# they get an error because the shebang is interpreted as including a
+# trailing `\r` character.
+*.sh text eol=lf


### PR DESCRIPTION
Addressing something that surfaced in #342 where WSL was used to run a shell script after cloning it on Windows with Git's `core.autocrlf` enabled.