### PR TITLE
Add README and publish script to apis crate

### DIFF
--- a/crates/apis/README.md
+++ b/crates/apis/README.md
@@ -1,0 +1,39 @@
+# javy-apis
+
+A collection of APIs that can be added to a Javy runtime.
+
+APIs are registered by enabling crate features.
+
+## Example usage
+
+```rust
+use javy::{quickjs::JSValue, Runtime};
+// with `console` feature enabled
+use javy_apis::RuntimeExt;
+
+fn main() -> Result<()> {
+    let runtime = Runtime::new_with_defaults()?;
+    let context = runtime.context();
+    context.eval_global("hello.js", "console.log('hello!');")?;
+    Ok(())
+}
+```
+
+## Features
+* `console` - registers an implementation of the `console` API
+* `text_encoding` - registers implementations of `TextEncoder` and `TextDecoder`
+* `stream_io` - registers implementations of `Javy.IO.readSync` and `Javy.IO.writeSync`
+
+## Building a project using this crate
+
+- Install the [wasi-sdk](https://github.com/WebAssembly/wasi-sdk#install) for your platform
+- Set the `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable to the absolute path where you installed the `wasi-sdk`
+
+For example, if you install the `wasi-sdk` in `/opt/wasi-sdk`, you can run:
+```bash
+export QUICKJS_WASM_SYS_WASI_SDK_PATH=/opt/wasi-sdk
+```
+
+## Publishing to crates.io
+
+To publish this crate to crates.io, run `./publish.sh`.

--- a/crates/apis/publish.sh
+++ b/crates/apis/publish.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ -z $QUICKJS_WASM_SYS_WASI_SDK_PATH ]]; then
+    echo "QUICKJS_WASM_SYS_WASI_SDK_PATH must be set to a path with a downloaded wasi-sdk" 1>&2
+    exit 1
+fi
+
+cargo publish --target=wasm32-wasi

--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -24,6 +24,11 @@
 //! context.eval_global("hello.js", "print('hello!');")?;
 //! # Ok::<(), Error>(())
 //! ```
+//!
+//! ## Features
+//! * `console` - registers an implementation of the `console` API
+//! * `text_encoding` - registers implementations of `TextEncoder` and `TextDecoder`
+//! * `stream_io` - registers implementations of `Javy.IO.readSync` and `Javy.IO.writeSync`
 
 use anyhow::Result;
 use javy::Runtime;


### PR DESCRIPTION
Part of #310. Adds a README and publish script to the `javy-apis` crate.