### PR TITLE
Use cargo-hack's each feature for testing apis crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install cargo-wasi
         run: cargo install cargo-wasi
 
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
       - name: Install wizer
         run: cargo install wizer --all-features
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test-javy:
 	cargo wasi test --package=javy --features json,messagepack -- --nocapture
 
 test-apis:
-	cargo wasi test --package=javy-apis --all-features -- --nocapture
+	cargo hack wasi test --package=javy-apis --each-feature -- --nocapture
 
 test-core:
 	cargo wasi test --package=javy-core -- --nocapture

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ We will only add JS APIs or accept contributions that add JS APIs that are poten
   `cargo-wasi`)
 - cargo-wasi, can be installed via `cargo install cargo-wasi`
 - wizer, can be installed via `cargo install wizer --all-features`
+- cargo-hack, can be installed via `cargo +stable install cargo-hack --locked`
 
 ## Building
 


### PR DESCRIPTION
The `javy-apis` crate can be a little tricky to validate if everything works as expected given that it needs to be tested with:
- all features disabled in case there's a `use` that refers to a disabled module 
- all features enabled in case two features try to define the same method on `APIConfig`
- one feature at a time enabled in case one feature is unintentionally dependent on another feature

We introduce using the `--each-feature` flag in [cargo-hack](https://github.com/taiki-e/cargo-hack) to ensure tests are run to cover all three cases outlined above.